### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a reproducible problem with the MBSE lab tooling.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include credentials, private model data, runtime databases, or unredacted diagnostics.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the commands or workflow that reproduces the issue.
+      placeholder: |
+        1. Run ...
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Docker version, Python version, and relevant command output.
+      render: text
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Redacted Diagnostics
+      description: Paste only redacted snippets that are needed to understand the problem.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security reports
+    url: mailto:cosgroma@gmail.com
+    about: Report vulnerabilities, leaked credentials, or private model exposure privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature Request
+description: Suggest a focused improvement to the MBSE lab tooling.
+title: "Feature: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or usability gap should this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the behavior you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Note any simpler or existing workflows that might solve the same problem.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Flexo deployment
+        - SysON deployment
+        - Flexo/SysON bridge
+        - Documentation
+        - Diagnostics
+        - Other
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] `make check`
+- [ ] `hatch run lint:all`
+- [ ] `make share-check`
+
+## Notes
+
+-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,3 @@ updates:
     target-branch: develop
     schedule:
       interval: weekly
-    target-branch: develop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     target-branch: develop
     schedule:
       interval: weekly
+    target-branch: develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -53,5 +53,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build docs
         run: hatch run docs:build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+This project is a practical engineering workspace for MBSE tooling. Keep
+discussion technical, respectful, and useful to people trying to run, inspect,
+or improve the lab.
+
+## Expected Behavior
+
+- Be direct without being dismissive.
+- Keep feedback focused on the work, evidence, and reproducible behavior.
+- Respect the boundary between this public tooling repo and private model data.
+- Avoid sharing credentials, proprietary model content, or sensitive deployment
+  details in issues, pull requests, logs, or examples.
+
+## Unacceptable Behavior
+
+- Harassment, threats, personal attacks, or discriminatory language.
+- Publishing another person's private information or private model content.
+- Deliberately disrupting project discussions, reviews, or automation.
+- Encouraging unsafe handling of credentials, service data, or private model
+  artifacts.
+
+## Reporting
+
+Report conduct concerns to `cosgroma@gmail.com`. Include the relevant links,
+screenshots, or context needed to understand the situation. Reports involving
+private information should avoid including unnecessary secrets or proprietary
+model data.
+
+Maintainers may remove comments, close issues, block participants, or take
+other reasonable actions needed to keep the project usable and safe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+Thanks for improving `mbse-lab`. This repository is a public tooling kit for
+local SysML v2 workflows with OpenMBEE Flexo MMS, Eclipse SysON, and the bridge
+scripts between them.
+
+## Repository Boundary
+
+Keep this repository focused on reusable tooling, documentation, public
+synthetic fixtures, and container setup. Do not add private SysML v2 models,
+runtime service data, credentials, generated diagnostics, or private exports.
+
+Use a separate private workspace for real model work:
+
+```bash
+export MBSE_MODEL_WORKSPACE=~/work/my-private-models
+```
+
+## Local Setup
+
+Install the CLI in editable mode:
+
+```bash
+make install-cli
+```
+
+Generate local environment files:
+
+```bash
+mbse-lab init --model-workspace ~/work/my-private-models
+```
+
+Run the environment doctor:
+
+```bash
+mbse-lab doctor
+```
+
+## Development Workflow
+
+This repo follows Git Flow:
+
+- Open feature and bugfix work against `develop`.
+- Reserve `main` for release and hotfix flow.
+- Keep changes small enough to validate and review.
+- Avoid unrelated refactors in focused fixes.
+
+Before opening a pull request, run:
+
+```bash
+make check
+```
+
+For broader changes or publication-sensitive changes, also run:
+
+```bash
+hatch run lint:all
+make share-check
+```
+
+When changing documentation structure, MkDocs configuration, or docs
+dependencies, run:
+
+```bash
+make docs-build
+```
+
+## Pull Requests
+
+Good pull requests include:
+
+- A concise summary of the user-facing or maintainer-facing change.
+- The validation commands that passed.
+- Notes about any checks that could not be run.
+- Screenshots or logs only when they are relevant and redacted.
+
+Do not include local `.env` files, service databases, diagnostics bundles,
+private Flexo exports, private rendered `.sysml` snapshots, or real model
+source.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mathew Cosgrove
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SysML v2 Local Lab Kit
 
+[![Community profile](https://img.shields.io/badge/dynamic/json?label=community&query=%24.health_percentage&suffix=%25&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fcosgroma%2Fmbse-lab%2Fcommunity%2Fprofile)](https://github.com/cosgroma/mbse-lab/community)
+
 This repo is a reusable local lab kit for starting SysML v2 work without making
 this repo the home for the models themselves. It provides:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # SysML v2 Local Lab Kit
 
 [![Community profile](https://img.shields.io/badge/dynamic/json?label=community&query=%24.health_percentage&suffix=%25&url=https%3A%2F%2Fapi.github.com%2Frepos%2Fcosgroma%2Fmbse-lab%2Fcommunity%2Fprofile)](https://github.com/cosgroma/mbse-lab/community)
+[![CI](https://github.com/cosgroma/mbse-lab/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/cosgroma/mbse-lab/actions/workflows/ci.yml)
+[![Docs](https://github.com/cosgroma/mbse-lab/actions/workflows/documentation.yml/badge.svg?branch=main)](https://github.com/cosgroma/mbse-lab/actions/workflows/documentation.yml)
+[![License: MIT](https://img.shields.io/github/license/cosgroma/mbse-lab)](LICENSE)
+[![Python >=3.10](https://img.shields.io/badge/python-%3E%3D3.10-blue)](pyproject.toml)
+[![SysML v2](https://img.shields.io/badge/SysML-v2-6f42c1)](https://github.com/cosgroma/mbse-lab)
 
 This repo is a reusable local lab kit for starting SysML v2 work without making
 this repo the home for the models themselves. It provides:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ this repo the home for the models themselves. It provides:
 
 The current integration path is intentionally file/text based:
 
-```text
-Flexo SysML v2 REST JSON -> SysML v2 textual .sysml -> SysON GraphQL import
+```mermaid
+flowchart LR
+    flexo["Flexo SysML v2 REST JSON"]
+    snapshot["SysML v2 textual snapshot<br/>.sysml"]
+    syson["SysON GraphQL import"]
+
+    flexo --> snapshot --> syson
 ```
 
 SysON and Flexo are separate repository stacks. Treat Flexo as the durable
@@ -32,6 +37,16 @@ diagnostics, documentation, and public synthetic fixtures. Keep real SysML v2
 models in a separate private workspace or private repository.
 
 Recommended layout:
+
+```mermaid
+flowchart LR
+    public["mbse-lab<br/>public tooling repo"]
+    private["private model workspace<br/>or private repository"]
+
+    public --> tooling["compose files<br/>CLI<br/>bridge scripts<br/>docs<br/>synthetic fixtures"]
+    private --> models["real SysML v2 models<br/>private exports<br/>generated snapshots"]
+    public -. "MBSE_MODEL_WORKSPACE" .-> private
+```
 
 ```text
 ~/work/sysmlv2-lab/             this shared tooling repo

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ through the Hatch-managed docs environment:
 make docs-build
 ```
 
+Release steps are documented in `docs/user-guide/release-process.md`.
+
 Serve it locally while editing:
 
 ```bash
@@ -113,6 +115,12 @@ Install the local CLI in editable mode:
 
 ```bash
 make install-cli
+```
+
+Install directly from GitHub when you do not need an editable checkout:
+
+```bash
+python3 -m pip install "git+https://github.com/cosgroma/mbse-lab.git"
 ```
 
 Then inspect the available commands:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled on the active `main` and `develop` branches.
+
+## Reporting a Vulnerability
+
+Do not open a public issue for suspected vulnerabilities, leaked credentials,
+or private model exposure.
+
+Report security issues to `cosgroma@gmail.com`. Include:
+
+- A short description of the issue.
+- Steps to reproduce when safe to share.
+- Affected files, commands, or deployment paths.
+- Any logs or diagnostics with secrets and private model data removed.
+
+The maintainer will review the report, ask for clarification if needed, and
+coordinate a fix before public disclosure when the issue affects users.
+
+## Sensitive Data
+
+This repository must not contain runtime credentials, private SysML v2 models,
+private exports, service databases, run logs, or diagnostics bundles. Run the
+share check before publishing changes:
+
+```bash
+make share-check
+```

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,16 @@
+# Support
+
+Use GitHub issues for reproducible problems, documentation gaps, and focused
+feature requests related to this public tooling repo.
+
+Before opening an issue:
+
+- Check `README.md` and the documentation under `docs/`.
+- Run `mbse-lab doctor` for local setup problems.
+- Run `make status` when reporting service state.
+- Remove credentials, private model data, local paths that should stay private,
+  and proprietary logs from shared output.
+
+This project does not provide support for private SysML v2 model content in
+public issues. Keep private model troubleshooting in your private workspace or
+private repository.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -20,3 +20,7 @@ Each plan should include:
 Small changes do not need a checked-in plan. Large bridge changes, persistence
 changes, credential handling changes, and live-service workflow changes should
 use one.
+
+## Active Plans
+
+- [MVP Feature Catalog](active/mvp-feature-catalog.md)

--- a/docs/plans/active/mvp-feature-catalog.md
+++ b/docs/plans/active/mvp-feature-catalog.md
@@ -23,9 +23,9 @@ features that still need development or release hardening.
 | Feature | Status | Current evidence | MVP gap |
 | --- | --- | --- | --- |
 | Public repo identity and community readiness | Verified | README badges, MIT license, community files, GitHub community profile reports 100%. | None for MVP. |
-| Git Flow and repository automation | Verified | `git-flow-policy.yml`, CI, Pages workflow, Dependabot targeting `develop`, branch policy runs. | Release merge procedure should be documented before first tagged release. |
+| Git Flow and repository automation | Verified | `git-flow-policy.yml`, CI, Pages workflow, Dependabot targeting `develop`, branch policy runs, release process docs. | Run the release procedure for the first tagged release. |
 | Documentation site | Verified | MkDocs config, docs workflow, GitHub Pages deployment, `make docs-build`. | None for MVP. |
-| Local editable CLI install | Verified | `pyproject.toml`, `mbse-lab` console script, `make install-cli`, CLI docs. | A one-line install-from-GitHub command would improve first-time usability. |
+| CLI install paths | Verified | `pyproject.toml`, `mbse-lab` console script, `make install-cli`, editable install docs, install-from-GitHub docs. | Validate direct GitHub install in a fresh virtual environment before first release. |
 | CLI shell completion | Verified | `mbse-lab completion bash/zsh/fish`, deterministic CLI evals. | None for MVP. |
 | Environment doctor | Verified | `mbse-lab doctor`, JSON output, `doctor --fix`, deterministic CLI evals. | Doctor could produce clearer next-step grouping, but current behavior is MVP-usable. |
 | Local runtime initialization | Verified | `mbse-lab init`, Flexo env generation, SysON env creation, dry-run tests. | Actual first-run smoke should be validated on a clean machine or container host before MVP announcement. |
@@ -61,21 +61,15 @@ features that still need development or release hardening.
    mbse-lab share-check
    ```
 
-2. Add a short release procedure for Git Flow:
-
-   ```text
-   develop -> release/* -> main
-   main tag -> GitHub release
-   main back-merge or sync -> develop
-   ```
-
-3. Add an install-from-GitHub path for users who do not want an editable clone:
+2. Validate direct GitHub install in a fresh virtual environment:
 
    ```bash
-   python3 -m pip install "git+https://github.com/cosgroma/mbse-lab.git"
+   python3 -m venv /tmp/mbse-lab-install-smoke
+   /tmp/mbse-lab-install-smoke/bin/python -m pip install "git+https://github.com/cosgroma/mbse-lab.git@develop"
+   /tmp/mbse-lab-install-smoke/bin/mbse-lab --help
    ```
 
-4. Decide whether the MVP promises only local Docker use or also supports a
+3. Decide whether the MVP promises only local Docker use or also supports a
    remote Flexo/SysON endpoint profile. The current CLI has URL options, but the
    documented happy path is local Docker.
 

--- a/docs/plans/active/mvp-feature-catalog.md
+++ b/docs/plans/active/mvp-feature-catalog.md
@@ -31,7 +31,7 @@ features that still need development or release hardening.
 | Local runtime initialization | Verified | `mbse-lab init`, Flexo env generation, SysON env creation, dry-run tests, live smoke workspace initialization. | None for MVP. |
 | Guided bootstrap | Partially verified | `mbse-lab bootstrap`, dry-run tests, docs. | Needs live end-to-end validation from a clean repo checkout with Docker running. |
 | Flexo deployment management | Verified | Flexo compose config is checked, env manager exists, service wrappers exist, status command exists, live smoke reported Flexo containers running and Flexo projects API HTTP 200. | None for MVP. |
-| SysON deployment management | Verified | SysON compose config is checked, service wrappers exist, status command exists, live smoke reported SysON app running and web UI HTTP 200. | Add a doctor hint for persisted database password drift when this recurs. |
+| SysON deployment management | Verified | SysON compose config is checked, service wrappers exist, status command exists, doctor checks persisted database credential drift, live smoke reported SysON app running and web UI HTTP 200. | None for MVP. |
 | Private model workspace boundary | Verified | `MBSE_MODEL_WORKSPACE`, workspace init/check/env, share-check protections, README/docs diagrams. | None for MVP. |
 | Share-safety checks | Verified | `mbse-lab share-check`, forbidden path scan, secret-like pattern scan, CI/check integration. | Add more patterns only as specific risks appear. |
 | Flexo project operations | Verified | CLI wrappers for list/create/export, bridge script commands, live Flexo eval, live first-model project creation and export. | None for MVP. |
@@ -99,8 +99,7 @@ Local-state note:
    remote Flexo/SysON endpoint profile. The current CLI has URL options, but the
    documented happy path is local Docker.
 
-2. Consider adding a doctor check for SysON persisted database credential drift
-   when `deploy/syson/.env` and `deploy/syson/data/postgres/` disagree.
+2. Keep watching for first-run friction during release candidates.
 
 ## Deferred Beyond MVP
 

--- a/docs/plans/active/mvp-feature-catalog.md
+++ b/docs/plans/active/mvp-feature-catalog.md
@@ -25,53 +25,82 @@ features that still need development or release hardening.
 | Public repo identity and community readiness | Verified | README badges, MIT license, community files, GitHub community profile reports 100%. | None for MVP. |
 | Git Flow and repository automation | Verified | `git-flow-policy.yml`, CI, Pages workflow, Dependabot targeting `develop`, branch policy runs, release process docs. | Run the release procedure for the first tagged release. |
 | Documentation site | Verified | MkDocs config, docs workflow, GitHub Pages deployment, `make docs-build`. | None for MVP. |
-| CLI install paths | Verified | `pyproject.toml`, `mbse-lab` console script, `make install-cli`, editable install docs, install-from-GitHub docs. | Validate direct GitHub install in a fresh virtual environment before first release. |
+| CLI install paths | Verified | `pyproject.toml`, `mbse-lab` console script, `make install-cli`, editable install docs, install-from-GitHub docs, fresh virtualenv install from GitHub `develop`. | None for MVP. |
 | CLI shell completion | Verified | `mbse-lab completion bash/zsh/fish`, deterministic CLI evals. | None for MVP. |
 | Environment doctor | Verified | `mbse-lab doctor`, JSON output, `doctor --fix`, deterministic CLI evals. | Doctor could produce clearer next-step grouping, but current behavior is MVP-usable. |
-| Local runtime initialization | Verified | `mbse-lab init`, Flexo env generation, SysON env creation, dry-run tests. | Actual first-run smoke should be validated on a clean machine or container host before MVP announcement. |
+| Local runtime initialization | Verified | `mbse-lab init`, Flexo env generation, SysON env creation, dry-run tests, live smoke workspace initialization. | None for MVP. |
 | Guided bootstrap | Partially verified | `mbse-lab bootstrap`, dry-run tests, docs. | Needs live end-to-end validation from a clean repo checkout with Docker running. |
-| Flexo deployment management | Partially verified | Flexo compose config is checked, env manager exists, service wrappers exist, status command exists. | Live startup and org initialization need an explicit MVP smoke checklist. |
-| SysON deployment management | Partially verified | SysON compose config is checked, service wrappers exist, status command exists. | Live startup and web/API reachability need an explicit MVP smoke checklist. |
+| Flexo deployment management | Verified | Flexo compose config is checked, env manager exists, service wrappers exist, status command exists, live smoke reported Flexo containers running and Flexo projects API HTTP 200. | None for MVP. |
+| SysON deployment management | Verified | SysON compose config is checked, service wrappers exist, status command exists, live smoke reported SysON app running and web UI HTTP 200. | Add a doctor hint for persisted database password drift when this recurs. |
 | Private model workspace boundary | Verified | `MBSE_MODEL_WORKSPACE`, workspace init/check/env, share-check protections, README/docs diagrams. | None for MVP. |
 | Share-safety checks | Verified | `mbse-lab share-check`, forbidden path scan, secret-like pattern scan, CI/check integration. | Add more patterns only as specific risks appear. |
-| Flexo project operations | Partially verified | CLI wrappers for list/create/export, bridge script commands, live Flexo eval exists. | Needs live validation against current Flexo containers before MVP release. |
-| SysON project operations | Partially verified | CLI wrappers for list/create/roots/import, bridge script commands, live SysON eval exists. | Needs live validation against current SysON containers before MVP release. |
+| Flexo project operations | Verified | CLI wrappers for list/create/export, bridge script commands, live Flexo eval, live first-model project creation and export. | None for MVP. |
+| SysON project operations | Verified | CLI wrappers for list/create/roots/import, bridge script commands, live SysON eval, live first-model review project and import. | None for MVP. |
 | Conservative SysML rendering | Verified | Deterministic renderer evals for basic package, RF link budget, and container deployment fixtures. | Rendering scope is intentionally limited; unsupported element behavior must remain documented. |
-| Flexo-to-SysON snapshot bridge | Partially verified | `flexo-to-syson`, run logs, deterministic wrapper tests, live evals exist. | Needs live full-bridge validation on running Flexo and SysON before MVP release. |
-| First model workflow | Partially verified | `mbse-lab first-model`, dry-run test, model service code. | Needs live validation creating a disposable Flexo project and SysON review project through the CLI. |
+| Flexo-to-SysON snapshot bridge | Verified | `flexo-to-syson`, run logs, deterministic wrapper tests, live evals, live first-model import into SysON. | None for MVP. |
+| First model workflow | Verified | `mbse-lab first-model`, dry-run test, model service code, live smoke model created and imported. | None for MVP. |
 | Deployment contract inspection | Verified | Container deployment fixture, `deployment contract`, deterministic evals. | None for MVP. |
-| Runtime deployment verification | Partially verified | `deployment verify`, deterministic report evals, optional live deployment eval. | Needs live verification run against the current Docker stack before MVP release. |
-| Diagnostics bundle | Verified | `mbse-lab diagnostics`, `collect_diagnostics.py`, diagnostics manifest evals. | Confirm redaction against a real failed-service bundle before broad sharing. |
+| Runtime deployment verification | Verified | `deployment verify`, deterministic report evals, optional live deployment eval, live smoke reported 9 services and 19 checks passing. | None for MVP. |
+| Diagnostics bundle | Verified | `mbse-lab diagnostics`, `collect_diagnostics.py`, diagnostics manifest evals, live diagnostics bundle collection. | Continue checking redaction when adding new diagnostic artifacts. |
 | Static local lab report | Verified | `mbse-lab report`, Markdown/HTML/JSON outputs, deterministic CLI eval. | None for MVP. |
 | Cleanup of generated local artifacts | Verified | `mbse-lab cleanup`, dry-run and removal evals, protected paths. | None for MVP. |
 | Published example fixtures | Verified | Public fixtures under `evals/fixtures`, deterministic evals, curated `exports/README.md`. | Keep fixture content synthetic and small. |
 | Known limitations and modeling conventions | Verified | `AGENTS.md`, bridge docs, modeling conventions docs. | README should continue to keep limitations concise and link to detailed docs. |
 
+## Live Validation Results
+
+Live validation on May 1, 2026 passed against the local Docker stack after
+aligning the ignored local SysON env file with the existing persisted database
+password.
+
+Commands run:
+
+```bash
+python3 -m venv /tmp/mbse-lab-install-smoke
+/tmp/mbse-lab-install-smoke/bin/python -m pip install "git+https://github.com/cosgroma/mbse-lab.git@develop"
+/tmp/mbse-lab-install-smoke/bin/mbse-lab --help
+export MBSE_MODEL_WORKSPACE=~/workspace/projects/mbse-mvp-smoke-models
+mbse-lab init --model-workspace "$MBSE_MODEL_WORKSPACE"
+mbse-lab doctor
+mbse-lab services up
+mbse-lab first-model "MVP Smoke Model" --json-output
+mbse-lab deployment verify
+make live-eval
+mbse-lab diagnostics
+mbse-lab share-check
+```
+
+Observed results:
+
+- GitHub install from `develop` resolved commit `e819d25` and exposed the CLI.
+- `mbse-lab doctor` reported Python, Docker, Docker Compose, repo markers,
+  `MBSE_MODEL_WORKSPACE`, Flexo, and SysON as OK.
+- `mbse-lab first-model` created Flexo project
+  `aceb2496-9cca-4e97-9b17-bcfd5b076a4b` and SysON review project
+  `3a8a0b23-af07-4b73-a789-8dd714d66612`.
+- Generated smoke artifacts were written under
+  `~/workspace/projects/mbse-mvp-smoke-models/exports/`.
+- `mbse-lab deployment verify` passed with 9 services and 19 checks.
+- `make live-eval` ran 4 live tests successfully.
+- `mbse-lab diagnostics` wrote `diagnostics/latest`.
+- `mbse-lab share-check` passed after live validation.
+
+Local-state note:
+
+- The first smoke attempt exposed a local SysON credential drift: the persisted
+  Postgres data volume was initialized with password `password`, while ignored
+  `deploy/syson/.env` contained `change-me`. Updating the ignored local env file
+  to match the existing database allowed SysON to start without deleting runtime
+  data.
+
 ## Required MVP Work Remaining
 
-1. Run a clean live smoke pass with Docker:
-
-   ```bash
-   mbse-lab init --model-workspace ~/workspace/projects/mbse-mvp-smoke-models
-   mbse-lab doctor
-   mbse-lab services up
-   mbse-lab first-model "MVP Smoke Model"
-   mbse-lab deployment verify
-   make live-eval
-   mbse-lab share-check
-   ```
-
-2. Validate direct GitHub install in a fresh virtual environment:
-
-   ```bash
-   python3 -m venv /tmp/mbse-lab-install-smoke
-   /tmp/mbse-lab-install-smoke/bin/python -m pip install "git+https://github.com/cosgroma/mbse-lab.git@develop"
-   /tmp/mbse-lab-install-smoke/bin/mbse-lab --help
-   ```
-
-3. Decide whether the MVP promises only local Docker use or also supports a
+1. Decide whether the MVP promises only local Docker use or also supports a
    remote Flexo/SysON endpoint profile. The current CLI has URL options, but the
    documented happy path is local Docker.
+
+2. Consider adding a doctor check for SysON persisted database credential drift
+   when `deploy/syson/.env` and `deploy/syson/data/postgres/` disagree.
 
 ## Deferred Beyond MVP
 

--- a/docs/plans/active/mvp-feature-catalog.md
+++ b/docs/plans/active/mvp-feature-catalog.md
@@ -1,0 +1,99 @@
+# MVP Feature Catalog
+
+## Objective
+
+Define the minimum useful release shape for `mbse-lab`: a public tooling repo
+that lets a user bootstrap a local SysML v2 lab, keep private models outside
+the tooling repo, run Flexo and SysON, move conservative model snapshots between
+them, and verify that the repo is safe to share.
+
+This catalog distinguishes features that are implemented and verified from
+features that still need development or release hardening.
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| Verified | Implemented and covered by deterministic checks, GitHub CI, docs validation, or community profile checks. |
+| Partially verified | Implemented, but the important user path depends on live services, manual validation, or incomplete automated coverage. |
+| Needs development | Required for a strong MVP but not yet implemented or not yet usable enough. |
+
+## Required MVP Features
+
+| Feature | Status | Current evidence | MVP gap |
+| --- | --- | --- | --- |
+| Public repo identity and community readiness | Verified | README badges, MIT license, community files, GitHub community profile reports 100%. | None for MVP. |
+| Git Flow and repository automation | Verified | `git-flow-policy.yml`, CI, Pages workflow, Dependabot targeting `develop`, branch policy runs. | Release merge procedure should be documented before first tagged release. |
+| Documentation site | Verified | MkDocs config, docs workflow, GitHub Pages deployment, `make docs-build`. | None for MVP. |
+| Local editable CLI install | Verified | `pyproject.toml`, `mbse-lab` console script, `make install-cli`, CLI docs. | A one-line install-from-GitHub command would improve first-time usability. |
+| CLI shell completion | Verified | `mbse-lab completion bash/zsh/fish`, deterministic CLI evals. | None for MVP. |
+| Environment doctor | Verified | `mbse-lab doctor`, JSON output, `doctor --fix`, deterministic CLI evals. | Doctor could produce clearer next-step grouping, but current behavior is MVP-usable. |
+| Local runtime initialization | Verified | `mbse-lab init`, Flexo env generation, SysON env creation, dry-run tests. | Actual first-run smoke should be validated on a clean machine or container host before MVP announcement. |
+| Guided bootstrap | Partially verified | `mbse-lab bootstrap`, dry-run tests, docs. | Needs live end-to-end validation from a clean repo checkout with Docker running. |
+| Flexo deployment management | Partially verified | Flexo compose config is checked, env manager exists, service wrappers exist, status command exists. | Live startup and org initialization need an explicit MVP smoke checklist. |
+| SysON deployment management | Partially verified | SysON compose config is checked, service wrappers exist, status command exists. | Live startup and web/API reachability need an explicit MVP smoke checklist. |
+| Private model workspace boundary | Verified | `MBSE_MODEL_WORKSPACE`, workspace init/check/env, share-check protections, README/docs diagrams. | None for MVP. |
+| Share-safety checks | Verified | `mbse-lab share-check`, forbidden path scan, secret-like pattern scan, CI/check integration. | Add more patterns only as specific risks appear. |
+| Flexo project operations | Partially verified | CLI wrappers for list/create/export, bridge script commands, live Flexo eval exists. | Needs live validation against current Flexo containers before MVP release. |
+| SysON project operations | Partially verified | CLI wrappers for list/create/roots/import, bridge script commands, live SysON eval exists. | Needs live validation against current SysON containers before MVP release. |
+| Conservative SysML rendering | Verified | Deterministic renderer evals for basic package, RF link budget, and container deployment fixtures. | Rendering scope is intentionally limited; unsupported element behavior must remain documented. |
+| Flexo-to-SysON snapshot bridge | Partially verified | `flexo-to-syson`, run logs, deterministic wrapper tests, live evals exist. | Needs live full-bridge validation on running Flexo and SysON before MVP release. |
+| First model workflow | Partially verified | `mbse-lab first-model`, dry-run test, model service code. | Needs live validation creating a disposable Flexo project and SysON review project through the CLI. |
+| Deployment contract inspection | Verified | Container deployment fixture, `deployment contract`, deterministic evals. | None for MVP. |
+| Runtime deployment verification | Partially verified | `deployment verify`, deterministic report evals, optional live deployment eval. | Needs live verification run against the current Docker stack before MVP release. |
+| Diagnostics bundle | Verified | `mbse-lab diagnostics`, `collect_diagnostics.py`, diagnostics manifest evals. | Confirm redaction against a real failed-service bundle before broad sharing. |
+| Static local lab report | Verified | `mbse-lab report`, Markdown/HTML/JSON outputs, deterministic CLI eval. | None for MVP. |
+| Cleanup of generated local artifacts | Verified | `mbse-lab cleanup`, dry-run and removal evals, protected paths. | None for MVP. |
+| Published example fixtures | Verified | Public fixtures under `evals/fixtures`, deterministic evals, curated `exports/README.md`. | Keep fixture content synthetic and small. |
+| Known limitations and modeling conventions | Verified | `AGENTS.md`, bridge docs, modeling conventions docs. | README should continue to keep limitations concise and link to detailed docs. |
+
+## Required MVP Work Remaining
+
+1. Run a clean live smoke pass with Docker:
+
+   ```bash
+   mbse-lab init --model-workspace ~/workspace/projects/mbse-mvp-smoke-models
+   mbse-lab doctor
+   mbse-lab services up
+   mbse-lab first-model "MVP Smoke Model"
+   mbse-lab deployment verify
+   make live-eval
+   mbse-lab share-check
+   ```
+
+2. Add a short release procedure for Git Flow:
+
+   ```text
+   develop -> release/* -> main
+   main tag -> GitHub release
+   main back-merge or sync -> develop
+   ```
+
+3. Add an install-from-GitHub path for users who do not want an editable clone:
+
+   ```bash
+   python3 -m pip install "git+https://github.com/cosgroma/mbse-lab.git"
+   ```
+
+4. Decide whether the MVP promises only local Docker use or also supports a
+   remote Flexo/SysON endpoint profile. The current CLI has URL options, but the
+   documented happy path is local Docker.
+
+## Deferred Beyond MVP
+
+- Full SysML v2 element coverage.
+- Diagram layout round-trip between Flexo and SysON.
+- Live repository synchronization between Flexo and SysON.
+- Hosted package distribution through PyPI.
+- Automated CI that starts the full Docker stack on every push.
+- Rich model templates beyond the tiny first-model flow.
+
+## Validation To Keep Current
+
+Run the deterministic baseline after changing this catalog:
+
+```bash
+make check
+```
+
+Run the live smoke pass before calling the MVP release-ready.

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -60,7 +60,10 @@ mbse-lab doctor
 
 The doctor checks Python, Docker, Docker Compose, expected repo files, local
 runtime env files, `MBSE_MODEL_WORKSPACE`, common service ports, and basic Flexo
-and SysON reachability.
+and SysON reachability. When SysON has persisted Postgres data and the database
+container is running, it also checks whether the ignored local
+`deploy/syson/.env` password works with that persisted database. This catches
+the common case where `syson-app` exits after a local `.env` password change.
 
 Print a structured report for automation:
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -18,6 +18,20 @@ Equivalent explicit command:
 python3 -m pip install -e .
 ```
 
+Install directly from GitHub when you want the command without an editable
+working copy:
+
+```bash
+python3 -m pip install "git+https://github.com/cosgroma/mbse-lab.git"
+```
+
+Install from the active development branch when you want the latest unreleased
+changes:
+
+```bash
+python3 -m pip install "git+https://github.com/cosgroma/mbse-lab.git@develop"
+```
+
 Check the command surface:
 
 ```bash

--- a/docs/user-guide/release-process.md
+++ b/docs/user-guide/release-process.md
@@ -37,6 +37,21 @@ mbse-lab share-check
 The live smoke pass creates disposable Flexo and SysON projects and writes
 generated artifacts under the private model workspace.
 
+## Troubleshooting Live Smoke
+
+If `syson-app` exits with a Postgres message such as:
+
+```text
+FATAL: password authentication failed for user "username"
+```
+
+then the ignored local `deploy/syson/.env` file probably does not match the
+password stored in the existing `deploy/syson/data/postgres/` runtime data.
+Align the ignored `.env` file with the existing local database password, or
+back up and reset the SysON runtime data before starting SysON again.
+
+Do not commit `deploy/syson/.env` or `deploy/syson/data/postgres/`.
+
 ## Prepare A Release Branch
 
 Start the release from `develop`:

--- a/docs/user-guide/release-process.md
+++ b/docs/user-guide/release-process.md
@@ -1,0 +1,91 @@
+# Release Process
+
+`mbse-lab` uses a lightweight Git Flow policy:
+
+```text
+feature/*, bugfix/*, dependabot/* -> develop
+release/*, hotfix/*               -> main
+```
+
+Use `develop` for normal integration work. Use `main` for the published,
+stable branch that users install from by default.
+
+## MVP Release Checklist
+
+Before opening a release branch:
+
+```bash
+hatch run lint:all
+make check
+make docs-build
+mbse-lab share-check
+```
+
+Run the live smoke pass when Docker is available:
+
+```bash
+export MBSE_MODEL_WORKSPACE=~/workspace/projects/mbse-mvp-smoke-models
+mbse-lab init --model-workspace "$MBSE_MODEL_WORKSPACE"
+mbse-lab doctor
+mbse-lab services up
+mbse-lab first-model "MVP Smoke Model"
+mbse-lab deployment verify
+make live-eval
+mbse-lab share-check
+```
+
+The live smoke pass creates disposable Flexo and SysON projects and writes
+generated artifacts under the private model workspace.
+
+## Prepare A Release Branch
+
+Start the release from `develop`:
+
+```bash
+git switch develop
+git pull --ff-only origin develop
+git switch -c release/v0.1.0
+```
+
+Update release-facing documentation or version metadata if needed, then run the
+release checklist. Commit any release-only cleanup on the `release/*` branch.
+
+Push the release branch and open a pull request into `main`:
+
+```bash
+git push -u origin release/v0.1.0
+gh pr create --base main --head release/v0.1.0 --title "Release v0.1.0" --body "Release v0.1.0"
+```
+
+Squash or merge the release PR according to the repository setting, then tag
+the resulting `main` commit:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v0.1.0 -m "v0.1.0"
+git push origin v0.1.0
+gh release create v0.1.0 --generate-notes
+```
+
+## Sync Back To Develop
+
+After `main` is released, bring the release commit back to `develop`:
+
+```bash
+git switch develop
+git pull --ff-only origin develop
+git merge --ff-only main
+git push origin develop
+```
+
+If `develop` has moved past the release branch, use a normal merge from `main`
+instead of forcing history:
+
+```bash
+git merge main
+git push origin develop
+```
+
+Do not rewrite `main` or release tags after a public release unless correcting a
+serious publication problem.

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from mbse_lab import cli  # noqa: E402
+from mbse_lab import cli, health  # noqa: E402
 
 
 class CliTests(unittest.TestCase):
@@ -94,6 +94,66 @@ class CliTests(unittest.TestCase):
         self.assertEqual(report["status"], "passed")
         self.assertTrue(report["checks"]["repo_root"]["ok"])
         self.assertIn("markers", report["checks"])
+
+    def test_syson_database_credential_report_passes_when_configured_password_works(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            (repo / "deploy/syson/data/postgres").mkdir(parents=True)
+            (repo / "deploy/syson/data/postgres/PG_VERSION").write_text("15\n", encoding="utf-8")
+            (repo / "deploy/syson/.env").write_text(
+                "SYSON_POSTGRES_IMAGE=postgres:15\n"
+                "SYSON_POSTGRES_DB=postgres\n"
+                "SYSON_POSTGRES_USER=username\n"
+                "SYSON_POSTGRES_PASSWORD=local-password\n",
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(health, "docker_container_report", return_value={"running": True}),
+                mock.patch.object(health, "run_capture_result", return_value=mock.Mock(returncode=0, stderr="")),
+            ):
+                report = health.syson_database_credential_report(repo)
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["status"], "passed")
+        self.assertTrue(report["data_exists"])
+
+    def test_syson_database_credential_report_warns_on_password_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            (repo / "deploy/syson/data/postgres").mkdir(parents=True)
+            (repo / "deploy/syson/data/postgres/PG_VERSION").write_text("15\n", encoding="utf-8")
+            (repo / "deploy/syson/.env").write_text(
+                "SYSON_POSTGRES_PASSWORD=wrong-password\n",
+                encoding="utf-8",
+            )
+            result = mock.Mock(returncode=2, stderr='FATAL: password authentication failed for user "username"')
+            with (
+                mock.patch.object(health, "docker_container_report", return_value={"running": True}),
+                mock.patch.object(health, "run_capture_result", return_value=result),
+            ):
+                report = health.syson_database_credential_report(repo)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "failed")
+        self.assertIn("does not match", report["detail"])
+
+    def test_syson_database_credential_report_treats_unreadable_data_dir_as_persisted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            data_path = repo / "deploy/syson/data/postgres"
+            data_path.mkdir(parents=True)
+            (repo / "deploy/syson/.env").write_text(
+                "SYSON_POSTGRES_PASSWORD=local-password\n",
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(health, "has_persisted_data", return_value=True),
+                mock.patch.object(health, "docker_container_report", return_value={"running": False}),
+            ):
+                report = health.syson_database_credential_report(repo)
+
+        self.assertTrue(report["data_exists"])
+        self.assertEqual(report["status"], "database-stopped")
 
     def test_doctor_fix_creates_syson_env_and_workspace_layout(self) -> None:
         runner = CliRunner()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - User Guide:
       - Private Model Workspaces: user-guide/private-model-workspaces.md
       - CLI: user-guide/cli.md
+      - Release Process: user-guide/release-process.md
   - Local Lab:
       - Bridge Workflow: lab/flexo-syson-bridge.md
       - Harness Engineering: lab/harness-engineering.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,9 @@ nav:
       - Container Deployment: model-specs/container-deployment.md
       - Security Architecture: model-specs/security-architecture.md
       - Enterprise Architecture: model-specs/enterprise-architecture.md
-  - Plans: plans/README.md
+  - Plans:
+      - Overview: plans/README.md
+      - MVP Feature Catalog: plans/active/mvp-feature-catalog.md
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "mbse-lab"
 version = "0.1.0"
 description = "CLI and local lab tooling for Flexo MMS, SysON, and SysML v2 workflows."
 readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",

--- a/src/mbse_lab/cli.py
+++ b/src/mbse_lab/cli.py
@@ -504,6 +504,14 @@ def doctor(ctx: click.Context, json_output: bool, fix: bool) -> None:
         status = fetch_status(url)
         warn_mark(label, status is not None and status < 500, f"status={status}" if status else url)
 
+    syson_database_credentials = report["checks"].get("syson_database_credentials")
+    if isinstance(syson_database_credentials, dict):
+        warn_mark(
+            "SysON database credentials",
+            bool(syson_database_credentials.get("ok")),
+            str(syson_database_credentials.get("detail", "")),
+        )
+
     if failures:
         raise click.ClickException(f"doctor found {failures} required failure(s)")
 

--- a/src/mbse_lab/health.py
+++ b/src/mbse_lab/health.py
@@ -51,6 +51,28 @@ def tcp_connects(host: str, port: int, timeout: float = 1.0) -> bool:
         return False
 
 
+def read_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def has_persisted_data(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        return any(path.iterdir())
+    except PermissionError:
+        return True
+
+
 def docker_container_report(name: str, repo_root: Path) -> dict[str, object]:
     result = run_capture_result(["docker", "inspect", name], repo_root)
     if result.returncode != 0:
@@ -78,6 +100,94 @@ def docker_container_report(name: str, repo_root: Path) -> dict[str, object]:
         "health": state.get("Health", {}).get("Status", "none"),
         "ports": ports,
     }
+
+
+def syson_database_credential_report(repo_root: Path) -> dict[str, object]:
+    env_path = repo_root / "deploy/syson/.env"
+    data_path = repo_root / "deploy/syson/data/postgres"
+    env_values = read_env_file(env_path)
+    database = env_values.get("SYSON_POSTGRES_DB", "postgres")
+    username = env_values.get("SYSON_POSTGRES_USER", "username")
+    password = env_values.get("SYSON_POSTGRES_PASSWORD")
+    image = env_values.get("SYSON_POSTGRES_IMAGE", "postgres:15")
+    data_exists = has_persisted_data(data_path)
+
+    report: dict[str, object] = {
+        "ok": True,
+        "status": "skipped",
+        "env_path": "deploy/syson/.env",
+        "data_path": "deploy/syson/data/postgres",
+        "env_exists": env_path.exists(),
+        "data_exists": data_exists,
+        "database_container_running": False,
+        "detail": "SysON database credential check skipped.",
+    }
+
+    if not env_path.exists():
+        report.update({"status": "missing-env", "detail": "deploy/syson/.env does not exist."})
+        return report
+    if not data_exists:
+        report.update({"status": "no-data", "detail": "No persisted SysON Postgres data found."})
+        return report
+    if not password:
+        report.update(
+            {
+                "ok": False,
+                "status": "missing-password",
+                "detail": "SYSON_POSTGRES_PASSWORD is missing from deploy/syson/.env.",
+            }
+        )
+        return report
+
+    database_container = docker_container_report("syson-database", repo_root)
+    container_running = bool(database_container.get("running"))
+    report["database_container_running"] = container_running
+    if not container_running:
+        report.update({"status": "database-stopped", "detail": "syson-database is not running."})
+        return report
+
+    result = run_capture_result(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--pull=never",
+            "--network",
+            "syson-test-network",
+            "-e",
+            f"PGPASSWORD={password}",
+            image,
+            "psql",
+            "-h",
+            "database",
+            "-U",
+            username,
+            "-d",
+            database,
+            "-c",
+            "select 1;",
+        ],
+        repo_root,
+    )
+    if result.returncode == 0:
+        report.update(
+            {
+                "ok": True,
+                "status": "passed",
+                "detail": "deploy/syson/.env password works with the running persisted SysON database.",
+            }
+        )
+        return report
+
+    stderr = result.stderr.strip()
+    if "password authentication failed" in stderr:
+        detail = "deploy/syson/.env password does not match the running persisted SysON database."
+    elif "No such image" in stderr or "pull access denied" in stderr:
+        detail = f"Could not run postgres client image without pulling: {image}."
+    else:
+        detail = "Could not verify SysON database credentials."
+    report.update({"ok": False, "status": "failed", "detail": detail})
+    return report
 
 
 def service_report(repo_root: Path) -> dict[str, object]:
@@ -138,6 +248,8 @@ def doctor_report(repo_root: Path | None) -> dict[str, object]:
             "syson_web": {"status": fetch_status(f"{DEFAULT_SYSON_URL}/")},
         },
     }
+    if repo_root:
+        checks["syson_database_credentials"] = syson_database_credential_report(repo_root)
     required_ok = (
         checks["python"]["ok"]
         and checks["docker"]["ok"]


### PR DESCRIPTION
## Summary

Release `v0.1.0` of `mbse-lab`, the MVP local SysML v2 lab kit for Flexo MMS, SysON, private model workspaces, bridge workflows, diagnostics, and share-safety checks.

## Highlights

- Adds community health files, README badges, and README Mermaid workflow diagrams.
- Updates GitHub Actions dependencies and Dependabot targeting for Git Flow.
- Adds MVP readiness catalog and release process documentation.
- Documents install-from-GitHub usage.
- Records live MVP validation results.
- Adds `doctor` detection for SysON persisted database credential drift.

## Validation

- `hatch run lint:all`
- `make check`
- `make docs-build`
- `mbse-lab share-check`

Live validation already recorded on `develop`:

- GitHub install from `develop`
- `mbse-lab init`
- `mbse-lab doctor`
- `mbse-lab services up`
- `mbse-lab first-model "MVP Smoke Model" --json-output`
- `mbse-lab deployment verify`
- `make live-eval`
- `mbse-lab diagnostics`
- `mbse-lab share-check`

## Notes

This release is scoped to local Docker deployment. Remote Flexo/SysON endpoint profiles are deferred beyond MVP.
