### PR TITLE
[codex] Improve docs discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ SysON and Flexo are separate repository stacks. Treat Flexo as the durable
 repository path for API-driven experiments, and use SysON for graphical review or
 editing of imported SysML v2 textual content.
 
+## Common Goals
+
+| I want to... | Use this | Details |
+| --- | --- | --- |
+| Install and inspect the command surface | `make install-cli` and `mbse-lab --help` | [CLI guide](docs/user-guide/cli.md) |
+| Bootstrap the local lab for first use | `mbse-lab bootstrap --model-workspace ~/work/my-private-models` | [CLI bootstrap](docs/user-guide/cli.md#bootstrap) |
+| Keep real model data outside this repo | `export MBSE_MODEL_WORKSPACE=~/work/my-private-models` | [Private model workspaces](docs/user-guide/private-model-workspaces.md) |
+| Create a tiny end-to-end model | `mbse-lab first-model "My First Model"` | [First model](docs/user-guide/cli.md#first-model) |
+| Move a Flexo snapshot into SysON | `mbse-lab bridge run <flexo-project-id>` | [Bridge workflow](docs/lab/flexo-syson-bridge.md) |
+| Check what the bridge can render | Review supported element mappings | [Modeling conventions](docs/lab/modeling-conventions.md) |
+| Collect failure evidence | `mbse-lab diagnostics` | [Harness engineering](docs/lab/harness-engineering.md#observability) |
+| Prepare a release | Run the release checklist | [Release process](docs/user-guide/release-process.md) |
+
 ## Tooling Repo, Not Model Repo
 
 Use this repo for the container deployment, setup scripts, bridge workflow,
@@ -62,25 +75,26 @@ export MBSE_MODEL_WORKSPACE=~/work/my-private-models
 
 With that variable set, `flexo-export`, `render-sysml`, and `flexo-to-syson`
 write generated artifacts under `$MBSE_MODEL_WORKSPACE/exports/` unless you pass
-explicit `--output` or `--output-dir` paths. See
-`docs/user-guide/private-model-workspaces.md` for the full boundary.
+explicit `--output` or `--output-dir` paths. See the
+[private model workspace guide](docs/user-guide/private-model-workspaces.md) for
+the full boundary.
 
 ## Layout
 
-```text
-deploy/flexo-mms/          Flexo MMS Docker Compose environment
-deploy/syson/              SysON Docker Compose environment
-docs/index.md              Documentation landing page
-docs/user-guide/           User guidance for private model workspaces
-docs/lab/                  Local lab operations and bridge guidance
-docs/methodology/          Reusable SysML v2 setup and transformation guidance
-docs/model-specs/          General-purpose model specifications
-docs/plans/                Active and completed execution plans
-exports/                   Curated publishable example exports only
-scripts/flexo_mms_env.py   Flexo environment manager
-scripts/flexo_syson_bridge.py
-                           Flexo/SysON bridge and helper CLI
-```
+| Path | Purpose |
+| --- | --- |
+| [deploy/flexo-mms/](deploy/flexo-mms/README.md) | Flexo MMS Docker Compose environment. |
+| [deploy/syson/](deploy/syson/README.md) | SysON Docker Compose environment. |
+| [docs/index.md](docs/index.md) | Documentation landing page and task router. |
+| [docs/user-guide/](docs/user-guide/cli.md) | CLI, release, and private workspace guidance. |
+| [docs/lab/](docs/lab/flexo-syson-bridge.md) | Local lab operations, bridge behavior, and harness notes. |
+| [docs/methodology/](docs/methodology/sysml-v2-verification-model-setup.md) | Reusable SysML v2 setup and transformation guidance. |
+| [docs/model-specs/](docs/model-specs/rf-link-budget.md) | General-purpose model specifications. |
+| [docs/plans/](docs/plans/README.md) | Active and completed execution plans. |
+| [exports/](exports/README.md) | Curated publishable example exports only. |
+| [WORKFLOW.md](WORKFLOW.md) | Repo-owned workflow contract for agent work. |
+| `scripts/flexo_mms_env.py` | Flexo environment manager. |
+| `scripts/flexo_syson_bridge.py` | Flexo/SysON bridge and helper CLI. |
 
 ## Requirements
 
@@ -101,7 +115,8 @@ through the Hatch-managed docs environment:
 make docs-build
 ```
 
-Release steps are documented in `docs/user-guide/release-process.md`.
+Release steps are documented in the
+[release process](docs/user-guide/release-process.md).
 
 Serve it locally while editing:
 
@@ -246,23 +261,16 @@ cp deploy/syson/.env.example deploy/syson/.env
 
 ## Services
 
-Flexo MMS:
-
-```text
-Layer1 API:     http://localhost:18080
-SysML v2 API:   http://localhost:18083
-Auth login:     http://localhost:8082/login
-Fuseki:         http://localhost:3030
-MinIO:          http://localhost:9000
-```
-
-SysON:
-
-```text
-Web UI:         http://localhost:18090
-GraphQL API:   http://localhost:18090/api/graphql
-REST API docs: http://localhost:18090/v3/api-docs/rest-apis
-```
+| Stack | Endpoint | URL |
+| --- | --- | --- |
+| Flexo MMS | Layer1 API | <http://localhost:18080> |
+| Flexo MMS | SysML v2 API | <http://localhost:18083> |
+| Flexo MMS | Auth login | <http://localhost:8082/login> |
+| Flexo MMS | Fuseki | <http://localhost:3030> |
+| Flexo MMS | MinIO | <http://localhost:9000> |
+| SysON | Web UI | <http://localhost:18090> |
+| SysON | GraphQL API | <http://localhost:18090/api/graphql> |
+| SysON | REST API docs | <http://localhost:18090/v3/api-docs/rest-apis> |
 
 ## Initialize
 
@@ -356,81 +364,21 @@ reset the environment.
 
 ## Common Workflows
 
-### List Flexo Projects
+| Workflow | CLI command | Script command |
+| --- | --- | --- |
+| List Flexo projects | `mbse-lab flexo list` | `python3 scripts/flexo_syson_bridge.py flexo-list-projects` |
+| Create a Flexo SysML v2 project | `mbse-lab flexo create "Example Model"` | `python3 scripts/flexo_syson_bridge.py flexo-create-project "Example Model"` |
+| Export Flexo JSON | `mbse-lab flexo export <flexo-project-id>` | `python3 scripts/flexo_syson_bridge.py flexo-export <flexo-project-id>` |
+| Render JSON to SysML text | `mbse-lab bridge render exports/flexo/<flexo-project-id>.json` | `python3 scripts/flexo_syson_bridge.py render-sysml exports/flexo/<flexo-project-id>.json` |
+| Create a SysON project | `mbse-lab syson create "Imported From Flexo"` | `python3 scripts/flexo_syson_bridge.py syson-create-project "Imported From Flexo"` |
+| Find a SysON import namespace | `mbse-lab syson roots <syson-project-id>` | `python3 scripts/flexo_syson_bridge.py syson-roots <syson-project-id>` |
+| Import a `.sysml` file into SysON | `mbse-lab bridge import exports/sysml/<flexo-project-id>.sysml --project-id <syson-project-id> --namespace-id <syson-root-package-id>` | `python3 scripts/flexo_syson_bridge.py syson-import-text exports/sysml/<flexo-project-id>.sysml --project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
+| Run the full Flexo-to-SysON pipeline | `mbse-lab bridge run <flexo-project-id> --syson-project-id <syson-project-id> --namespace-id <syson-root-package-id>` | `python3 scripts/flexo_syson_bridge.py flexo-to-syson <flexo-project-id> --syson-project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
 
-```bash
-python3 scripts/flexo_syson_bridge.py flexo-list-projects
-```
-
-### Create a Flexo SysML v2 Project
-
-```bash
-python3 scripts/flexo_syson_bridge.py flexo-create-project "Example Model"
-```
-
-### Export Flexo to JSON
-
-```bash
-python3 scripts/flexo_syson_bridge.py flexo-export <flexo-project-id>
-```
-
-Output:
-
-```text
-exports/flexo/<flexo-project-id>.json
-```
-
-### Render Flexo JSON to SysML Text
-
-```bash
-python3 scripts/flexo_syson_bridge.py render-sysml \
-  exports/flexo/<flexo-project-id>.json
-```
-
-Output:
-
-```text
-exports/sysml/<flexo-project-id>.sysml
-```
-
-### Create a SysON Project
-
-```bash
-python3 scripts/flexo_syson_bridge.py syson-create-project "Imported From Flexo"
-```
-
-The command prints the new SysON project ID.
-
-### Find a SysON Import Namespace
-
-SysON imports textual SysML into an existing namespace element, usually the root
-package from a new SysML v2 project:
-
-```bash
-python3 scripts/flexo_syson_bridge.py syson-roots <syson-project-id>
-```
-
-Use the printed package ID as `--namespace-id`.
-
-### Import a `.sysml` File Into SysON
-
-```bash
-python3 scripts/flexo_syson_bridge.py syson-import-text \
-  exports/sysml/<flexo-project-id>.sysml \
-  --project-id <syson-project-id> \
-  --namespace-id <syson-root-package-id>
-```
-
-### Full Flexo to SysON Pipeline
-
-```bash
-python3 scripts/flexo_syson_bridge.py flexo-to-syson <flexo-project-id> \
-  --syson-project-id <syson-project-id> \
-  --namespace-id <syson-root-package-id>
-```
-
-This writes both intermediate artifacts and imports the rendered `.sysml` file
-into SysON.
+Default artifacts are written under `exports/flexo/` and `exports/sysml/`, or
+under `$MBSE_MODEL_WORKSPACE/exports/` when the private workspace variable is
+set. The [bridge workflow](docs/lab/flexo-syson-bridge.md) has the full command
+sequence and output table.
 
 ## Stop and Restart
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,50 +4,69 @@ This documentation set supports the shareable SysML v2 local lab kit, private
 model workspace usage, SysML v2 modeling guidance, and publishable model
 specifications.
 
+## Start Here
+
+| Goal | Start with | Then use |
+| --- | --- | --- |
+| Install and operate the lab CLI | [CLI](user-guide/cli.md) | [Bridge Workflow](lab/flexo-syson-bridge.md) |
+| Keep private model data out of the tooling repo | [Private Model Workspaces](user-guide/private-model-workspaces.md) | [Modeling Conventions](lab/modeling-conventions.md) |
+| Move a Flexo model snapshot into SysON | [Bridge Workflow](lab/flexo-syson-bridge.md) | [Transformation Pipeline](methodology/sysml-v2-transformation-pipeline-design.md) |
+| Understand supported rendered SysML v2 content | [Modeling Conventions](lab/modeling-conventions.md) | [Bridge Workflow](lab/flexo-syson-bridge.md) |
+| Prepare or publish a release | [Release Process](user-guide/release-process.md) | [MVP Feature Catalog](plans/active/mvp-feature-catalog.md) |
+| Extend the local harness or evals | [Harness Engineering](lab/harness-engineering.md) | [Plans](plans/README.md) |
+
+## Local Lab Flow
+
+```mermaid
+flowchart LR
+    setup["CLI setup and doctor"]
+    flexo["Flexo MMS<br/>SysML v2 API"]
+    snapshot["Flexo JSON export<br/>rendered .sysml"]
+    syson["SysON<br/>graphical review"]
+    evidence["reports, diagnostics,<br/>eval evidence"]
+
+    setup --> flexo --> snapshot --> syson
+    setup --> evidence
+    snapshot --> evidence
+```
+
 ## User Guide
 
-```text
-docs/user-guide/private-model-workspaces.md
-                                  How to use this tooling repo while keeping
-                                  real SysML v2 models private
-docs/user-guide/cli.md            Installable CLI usage
-```
+| Page | Use it for |
+| --- | --- |
+| [Private Model Workspaces](user-guide/private-model-workspaces.md) | Separating reusable tooling from private SysML v2 source, exports, run logs, and service data. |
+| [CLI](user-guide/cli.md) | Installing `mbse-lab`, running doctor/bootstrap, managing services, creating a first model, and using bridge commands. |
+| [Release Process](user-guide/release-process.md) | Preparing release branches, smoke testing, tagging, and syncing release work back to `develop`. |
 
 ## Local Lab
 
-```text
-docs/lab/flexo-syson-bridge.md   Bridge workflow notes
-docs/lab/harness-engineering.md   Harness design and eval/diagnostics guidance
-docs/lab/modeling-conventions.md  Supported SysML v2 rendering subset
-```
+| Page | Use it for |
+| --- | --- |
+| [Bridge Workflow](lab/flexo-syson-bridge.md) | Exporting from Flexo, rendering textual SysML v2, and importing into SysON. |
+| [Harness Engineering](lab/harness-engineering.md) | Understanding command surfaces, guardrails, evals, diagnostics, and agent-oriented operating rules. |
+| [Modeling Conventions](lab/modeling-conventions.md) | Checking which Flexo element types are rendered into textual SysML v2 and how names are sanitized. |
 
 ## Methodology
 
-```text
-docs/methodology/sysml-v2-verification-model-setup.md
-                                  SysML v2 model organization guide for verification
-docs/methodology/sysml-v2-transformation-pipeline-design.md
-                                  SysML v2 transformation and analysis pipeline design
-```
+| Page | Use it for |
+| --- | --- |
+| [Verification Model Setup](methodology/sysml-v2-verification-model-setup.md) | Organizing SysML v2 packages, requirements, architecture, configurations, analysis, and verification content. |
+| [Transformation Pipeline](methodology/sysml-v2-transformation-pipeline-design.md) | Designing model-to-analysis, model-to-document, and evidence import pipelines around SysML v2 source content. |
 
 ## Model Specs
 
-```text
-docs/model-specs/rf-link-budget.md
-                                  RF link budget SysML v2 model specification
-docs/model-specs/cca-rollup.md    CCA power, mass, and cost rollup model specification
-docs/model-specs/rf-to-digital-signal-chain.md
-                                  RF front-end and digital signal chain model specification
-docs/model-specs/container-deployment.md
-                                  Container deployment and volume verification model specification
-docs/model-specs/security-architecture.md
-                                  Security architecture model specification aligned to UAF Security
-docs/model-specs/enterprise-architecture.md
-                                  Enterprise architecture model specification aligned to UAF concepts
-```
+| Page | Use it for |
+| --- | --- |
+| [RF Link Budget](model-specs/rf-link-budget.md) | Modeling RF link margin, budget equations, requirements, analysis cases, and verification evidence. |
+| [CCA Rollup](model-specs/cca-rollup.md) | Modeling circuit-card power, mass, cost, labor, test, and rollup verification. |
+| [RF to Digital Signal Chain](model-specs/rf-to-digital-signal-chain.md) | Modeling RF front-end, ADC, DSP, signal quality, and response artifacts. |
+| [Container Deployment](model-specs/container-deployment.md) | Modeling container services, ports, volumes, health checks, persistence, backup, and runtime verification. |
+| [Security Architecture](model-specs/security-architecture.md) | Modeling security assets, enclaves, controls, risks, mitigations, and evidence records. |
+| [Enterprise Architecture](model-specs/enterprise-architecture.md) | Modeling capabilities, activities, services, resources, projects, and enterprise traceability. |
 
 ## Plans
 
-```text
-docs/plans/README.md              Execution plan conventions
-```
+| Page | Use it for |
+| --- | --- |
+| [Plans](plans/README.md) | Execution plan conventions for active and completed work. |
+| [MVP Feature Catalog](plans/active/mvp-feature-catalog.md) | Current MVP feature status, evidence, gaps, and validation work. |

--- a/docs/lab/flexo-syson-bridge.md
+++ b/docs/lab/flexo-syson-bridge.md
@@ -2,8 +2,15 @@
 
 This is the initial bridge path:
 
-```text
-Flexo SysML v2 REST JSON -> SysML v2 textual .sysml -> SysON GraphQL import
+```mermaid
+flowchart LR
+    flexo["Flexo project<br/>SysML v2 REST API"]
+    export["Flexo JSON export<br/>exports/flexo/*.json"]
+    render["text renderer<br/>supported SysML v2 subset"]
+    sysml["SysML v2 text<br/>exports/sysml/*.sysml"]
+    syson["SysON project<br/>GraphQL textual import"]
+
+    flexo --> export --> render --> sysml --> syson
 ```
 
 The script is intentionally conservative. It preserves the Flexo JSON export and
@@ -28,7 +35,8 @@ $MBSE_MODEL_WORKSPACE/exports/
 ```
 
 Use explicit `--output` or `--output-dir` paths when a run needs a different
-location.
+location. The canonical boundary is documented in
+[Private Model Workspaces](../user-guide/private-model-workspaces.md).
 
 ## Preflight
 
@@ -50,45 +58,47 @@ python3 scripts/flexo_mms_env.py backup
 The backup matters because the local Fuseki container starts from
 `deploy/flexo-mms/mount/cluster.trig`.
 
+| Check | Command | Expected signal |
+| --- | --- | --- |
+| Flexo status | `python3 scripts/flexo_mms_env.py status --with-sysmlv2` | Flexo containers and SysML v2 service are reachable. |
+| SysON status | `docker compose -f deploy/syson/docker-compose.yml ps` | SysON application and database containers are running. |
+| Flexo org exists | `python3 scripts/flexo_syson_bridge.py init-flexo-org` | Needed only when project creation reports the missing `sysmlv2` org. |
+| Graph seed is current | `python3 scripts/flexo_mms_env.py backup` | `deploy/flexo-mms/mount/cluster.trig` reflects org/setup changes. |
+
 ## Flexo Commands
 
-```bash
-python3 scripts/flexo_syson_bridge.py flexo-list-projects
-python3 scripts/flexo_syson_bridge.py flexo-create-project "Example Model"
-python3 scripts/flexo_syson_bridge.py flexo-export <flexo-project-id>
-python3 scripts/flexo_syson_bridge.py render-sysml exports/flexo/<flexo-project-id>.json
-```
+| Task | CLI command | Script command |
+| --- | --- | --- |
+| List projects | `mbse-lab flexo list` | `python3 scripts/flexo_syson_bridge.py flexo-list-projects` |
+| Create project | `mbse-lab flexo create "Example Model"` | `python3 scripts/flexo_syson_bridge.py flexo-create-project "Example Model"` |
+| Export JSON | `mbse-lab flexo export <flexo-project-id>` | `python3 scripts/flexo_syson_bridge.py flexo-export <flexo-project-id>` |
+| Render SysML text | `mbse-lab bridge render exports/flexo/<flexo-project-id>.json` | `python3 scripts/flexo_syson_bridge.py render-sysml exports/flexo/<flexo-project-id>.json` |
 
 ## SysON Commands
 
-Create a SysON project:
+| Task | CLI command | Script command |
+| --- | --- | --- |
+| Create project | `mbse-lab syson create "Imported From Flexo"` | `python3 scripts/flexo_syson_bridge.py syson-create-project "Imported From Flexo"` |
+| Find import namespace | `mbse-lab syson roots <syson-project-id>` | `python3 scripts/flexo_syson_bridge.py syson-roots <syson-project-id>` |
+| Import SysML text | `mbse-lab bridge import exports/sysml/<flexo-project-id>.sysml --project-id <syson-project-id> --namespace-id <syson-root-package-id>` | `python3 scripts/flexo_syson_bridge.py syson-import-text exports/sysml/<flexo-project-id>.sysml --project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
+| Run full pipeline | `mbse-lab bridge run <flexo-project-id> --syson-project-id <syson-project-id> --namespace-id <syson-root-package-id>` | `python3 scripts/flexo_syson_bridge.py flexo-to-syson <flexo-project-id> --syson-project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
 
-```bash
-python3 scripts/flexo_syson_bridge.py syson-create-project "Imported From Flexo"
-```
-
-Find a namespace/root element to import into:
-
-```bash
-python3 scripts/flexo_syson_bridge.py syson-roots <syson-project-id>
-```
-
-Import a generated `.sysml` file:
-
-```bash
-python3 scripts/flexo_syson_bridge.py syson-import-text \
-  exports/sysml/<flexo-project-id>.sysml \
-  --project-id <syson-project-id> \
-  --namespace-id <syson-root-package-id>
-```
-
-Or run the full pipeline:
+For the full pipeline, the expanded script form is:
 
 ```bash
 python3 scripts/flexo_syson_bridge.py flexo-to-syson <flexo-project-id> \
   --syson-project-id <syson-project-id> \
   --namespace-id <syson-root-package-id>
 ```
+
+## Artifacts
+
+| Artifact | Default location | Share guidance |
+| --- | --- | --- |
+| Flexo JSON export | `exports/flexo/<flexo-project-id>.json` | Keep private unless the model is synthetic and publishable. |
+| Rendered SysML text | `exports/sysml/<flexo-project-id>.sysml` | Derived from the export; keep private for real models. |
+| Full-pipeline run log | `runs/flexo-to-syson/` | Ignored by git; may include private project IDs and names. |
+| Private workspace exports | `$MBSE_MODEL_WORKSPACE/exports/` | Preferred location for real model bridge artifacts. |
 
 ## Current Scope
 
@@ -112,3 +122,12 @@ The renderer currently handles a practical subset:
 
 Unsupported element types remain in the raw Flexo JSON export but are not emitted
 into the textual `.sysml` file yet.
+
+## Related Docs
+
+| Page | Why it matters |
+| --- | --- |
+| [CLI](../user-guide/cli.md) | Describes the user-facing `mbse-lab bridge`, `flexo`, and `syson` commands. |
+| [Private Model Workspaces](../user-guide/private-model-workspaces.md) | Defines where generated model artifacts should live. |
+| [Modeling Conventions](modeling-conventions.md) | Lists supported rendered element types and naming rules. |
+| [Transformation Pipeline](../methodology/sysml-v2-transformation-pipeline-design.md) | Places the bridge in the broader model transformation strategy. |

--- a/docs/lab/harness-engineering.md
+++ b/docs/lab/harness-engineering.md
@@ -18,21 +18,20 @@ this MBSE lab.
 
 ## Current Harness Pieces
 
-```text
-AGENTS.md                         Repo-local agent instructions
-README.md                         User-facing environment guide
-WORKFLOW.md                       Repo-owned workflow contract for agent runs
-Makefile                          Stable command surface for agents and humans
-scripts/flexo_mms_env.py          Environment setup, status, backup, rotation
-scripts/flexo_syson_bridge.py     Flexo/SysON workflow automation
-scripts/check_docs.py             Documentation link and command hygiene checks
-docs/user-guide/private-model-workspaces.md
-                                  Tooling repo versus private model workspace boundary
-docs/lab/flexo-syson-bridge.md        Bridge details
-docs/lab/modeling-conventions.md       Supported SysML v2 bridge subset
-docs/plans/README.md               Execution plan conventions
-deploy/*/*.example                Publishable config templates
-```
+| File or area | Harness role |
+| --- | --- |
+| `AGENTS.md` | Repo-local agent instructions. |
+| `README.md` | User-facing environment guide. |
+| `WORKFLOW.md` | Repo-owned workflow contract for agent runs. |
+| `Makefile` | Stable command surface for agents and humans. |
+| `scripts/flexo_mms_env.py` | Environment setup, status, backup, and rotation. |
+| `scripts/flexo_syson_bridge.py` | Flexo/SysON workflow automation. |
+| `scripts/check_docs.py` | Documentation link and command hygiene checks. |
+| [Private Model Workspaces](../user-guide/private-model-workspaces.md) | Tooling repo versus private model workspace boundary. |
+| [Bridge Workflow](flexo-syson-bridge.md) | Flexo export, SysML render, and SysON import details. |
+| [Modeling Conventions](modeling-conventions.md) | Supported SysML v2 bridge subset. |
+| [Plans](../plans/README.md) | Execution plan conventions. |
+| `deploy/*/*.example` | Publishable config templates. |
 
 ## Command Surface
 

--- a/docs/lab/modeling-conventions.md
+++ b/docs/lab/modeling-conventions.md
@@ -59,3 +59,11 @@ Before adding a new rendered element type:
 Prefer small, verified additions over broad guessed mappings. When Flexo JSON
 shape is unclear, preserve the raw JSON and defer textual rendering until the
 mapping can be tested.
+
+## Related Docs
+
+| Page | Why it matters |
+| --- | --- |
+| [Bridge Workflow](flexo-syson-bridge.md) | Shows where these mappings are used in the Flexo-to-SysON pipeline. |
+| [Transformation Pipeline](../methodology/sysml-v2-transformation-pipeline-design.md) | Describes broader transformation rules for model-derived artifacts. |
+| [Verification Model Setup](../methodology/sysml-v2-verification-model-setup.md) | Provides package and traceability conventions for source model structure. |

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -4,6 +4,19 @@ The `mbse-lab` CLI is the user-facing command surface for this local SysML v2
 lab kit. It wraps the existing Flexo, SysON, bridge, diagnostics, deployment,
 and private workspace workflows behind one command tree.
 
+## Command Map
+
+| Goal | Command family | Start with |
+| --- | --- | --- |
+| Check local setup | `doctor`, `status` | `mbse-lab doctor` |
+| Prepare runtime files | `init`, `bootstrap` | `mbse-lab bootstrap --model-workspace ~/work/my-private-models` |
+| Manage containers | `services` | `mbse-lab services up` |
+| Create a smoke-test model | `first-model` | `mbse-lab first-model "My First Model"` |
+| Keep artifacts private | `workspace` | `mbse-lab workspace init ~/work/my-private-models` |
+| Move snapshots between tools | `flexo`, `syson`, `bridge` | `mbse-lab bridge run <flexo-project-id>` |
+| Collect evidence | `diagnostics`, `report`, `deployment` | `mbse-lab diagnostics` |
+| Prepare sharing | `share-check`, `cleanup` | `mbse-lab share-check` |
+
 ## Install
 
 Install the CLI from this repo in editable mode:
@@ -326,3 +339,12 @@ another directory, pass `--repo-root`:
 ```bash
 mbse-lab --repo-root ~/work/sysmlv2-lab doctor
 ```
+
+## Related Docs
+
+| Page | Why it matters |
+| --- | --- |
+| [Private Model Workspaces](private-model-workspaces.md) | Explains the `MBSE_MODEL_WORKSPACE` boundary used by bridge commands. |
+| [Bridge Workflow](../lab/flexo-syson-bridge.md) | Shows the Flexo export, SysML render, and SysON import sequence. |
+| [Harness Engineering](../lab/harness-engineering.md) | Documents evals, diagnostics, reports, and guardrails behind the CLI. |
+| [Release Process](release-process.md) | Uses the CLI for release smoke tests and share checks. |

--- a/docs/user-guide/private-model-workspaces.md
+++ b/docs/user-guide/private-model-workspaces.md
@@ -9,31 +9,38 @@ home for private system models.
 
 Use separate directories for tooling and model data:
 
-```text
-~/work/sysmlv2-lab/             Shared tooling repo
-~/work/my-private-models/       Private model workspace or private repo
+```mermaid
+flowchart LR
+    tooling["Shared tooling repo<br/>mbse-lab"]
+    workspace["Private model workspace<br/>or private repo"]
+    exports["generated exports<br/>rendered .sysml<br/>run logs"]
+    services["local service data<br/>ignored runtime files"]
+
+    tooling --> scripts["CLI, scripts, docs,<br/>compose files, fixtures"]
+    tooling -. "MBSE_MODEL_WORKSPACE" .-> workspace
+    workspace --> exports
+    tooling -. "ignored" .-> services
 ```
 
 Keep this repo public or broadly shared. Keep real program, customer, product,
 or system models in the private workspace.
 
+| Location | Example | Contents |
+| --- | --- | --- |
+| Shared tooling repo | `~/work/sysmlv2-lab/` | Compose files, CLI, bridge scripts, docs, synthetic fixtures. |
+| Private model workspace | `~/work/my-private-models/` | Real model source, private exports, rendered snapshots, run evidence. |
+
 ## What Belongs In This Repo
 
-- Docker Compose files for Flexo and SysON.
-- Runtime setup, status, backup, diagnostics, and bridge scripts.
-- Publishable `.env.example` files.
-- Public synthetic fixtures and examples.
-- Documentation for operating the local lab.
-
-## What Belongs Outside This Repo
-
-- Real `.sysml` model source.
-- Flexo JSON exports from private projects.
-- Rendered SysML snapshots from private projects.
-- SysON database contents.
-- Flexo backup files that include private graph state.
-- Run logs that include private project IDs, names, or import details.
-- Runtime credentials and local `.env` files.
+| Belongs here | Belongs outside this repo |
+| --- | --- |
+| Docker Compose files for Flexo and SysON. | Real `.sysml` model source. |
+| Runtime setup, status, backup, diagnostics, and bridge scripts. | Flexo JSON exports from private projects. |
+| Publishable `.env.example` files. | Rendered SysML snapshots from private projects. |
+| Public synthetic fixtures and examples. | SysON database contents. |
+| Documentation for operating the local lab. | Flexo backup files that include private graph state. |
+|  | Run logs that include private project IDs, names, or import details. |
+|  | Runtime credentials and local `.env` files. |
 
 ## Workspace Environment Variable
 
@@ -88,3 +95,11 @@ make check
 That includes the tracked secret scan and confirms the deterministic bridge
 evals still pass. It does not inspect private model workspaces, so review those
 separately before sharing them.
+
+## Related Docs
+
+| Page | Why it matters |
+| --- | --- |
+| [CLI](cli.md) | Provides `mbse-lab workspace`, `bootstrap`, `doctor`, and `share-check` commands. |
+| [Bridge Workflow](../lab/flexo-syson-bridge.md) | Shows how generated Flexo and SysON artifacts flow through the private workspace boundary. |
+| [Harness Engineering](../lab/harness-engineering.md) | Documents diagnostics, run logs, evals, and share-safety guardrails. |

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import unquote
 
 ROOT = Path(__file__).resolve().parents[1]
 INDEX_FILES = [
@@ -26,6 +27,7 @@ IGNORED_DOCS = {
 COMMAND_LINE = re.compile(r"^\s*(?:[A-Z0-9_./-]+=\\S+\s+)*(make|python3|docker|curl|git|cp|jq)\b(.+)?$")
 PYTHON_SCRIPT = re.compile(r"python3\s+(scripts/[A-Za-z0-9_.\-/]+\.py)(?:\s+([A-Za-z0-9_-]+))?")
 MAKE_TARGET = re.compile(r"\bmake\s+([A-Za-z0-9_.-]+)")
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 
 
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -44,12 +46,26 @@ def tracked_and_untracked_docs() -> list[Path]:
     return sorted(path for path in docs if path.is_file())
 
 
-def visible_index_text() -> str:
-    parts = []
-    for path in INDEX_FILES:
-        if path.exists():
-            parts.append(path.read_text(encoding="utf-8"))
-    return "\n".join(parts)
+def linked_index_paths() -> set[str]:
+    linked: set[str] = set()
+    for source in INDEX_FILES:
+        if not source.exists():
+            continue
+        text = source.read_text(encoding="utf-8")
+        for raw_target in MARKDOWN_LINK.findall(text):
+            target = raw_target.strip().split()[0]
+            if not target or target.startswith("#") or re.match(r"^[a-z][a-z0-9+.-]*:", target, re.IGNORECASE):
+                continue
+            target = unquote(target.split("#", 1)[0].split("?", 1)[0])
+            if not target:
+                continue
+            resolved = (source.parent / target).resolve()
+            try:
+                relative = resolved.relative_to(ROOT)
+            except ValueError:
+                continue
+            linked.add(relative.as_posix())
+    return linked
 
 
 def make_targets() -> set[str]:
@@ -98,15 +114,19 @@ def command_blocks(path: Path) -> list[str]:
 
 
 def check_discoverability(failures: list[str]) -> None:
-    index = visible_index_text()
+    linked_paths = linked_index_paths()
     for path in tracked_and_untracked_docs():
         relative = path.relative_to(ROOT).as_posix()
         if relative in {"README.md", "AGENTS.md"} or relative in IGNORED_DOCS:
             continue
         if relative.startswith("docs/plans/active/") or relative.startswith("docs/plans/completed/"):
             continue
-        if relative not in index:
-            fail(f"{relative} is not referenced by README.md, AGENTS.md, docs/index.md, or harness guidance", failures)
+        if relative not in linked_paths:
+            fail(
+                f"{relative} is not linked from README.md, WORKFLOW.md, AGENTS.md, "
+                "docs/index.md, or harness guidance",
+                failures,
+            )
 
 
 def check_make_commands(failures: list[str]) -> None:


### PR DESCRIPTION
## Summary
- Rework the README and docs homepage around task-oriented navigation tables.
- Add Mermaid diagrams, command/artifact tables, and related-doc links to key user-guide and lab pages.
- Strengthen docs-check so discoverability requires real Markdown links instead of plain path mentions.

## Validation
- make docs-check
- python3 -m py_compile scripts/check_docs.py
- make docs-build