### PR TITLE
[codex] First-use workflow hardening

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -181,7 +181,11 @@ snapshots, or real model source. Commit publishable examples and deterministic
 fixtures only.
 
 Use `MBSE_MODEL_WORKSPACE` or explicit bridge output paths when generated model
-artifacts belong in a private workspace outside this repo.
+artifacts belong in a private workspace outside this repo. Commands that write
+model artifacts (`first-model`, `flexo export`, `bridge render`, `bridge run`)
+warn when neither `MBSE_MODEL_WORKSPACE` nor an explicit `--output` path is
+provided. Pass `--allow-repo-exports` only when intentionally writing curated
+example output under `exports/` in this shared tooling repo.
 
 Before destructive reset actions, such as deleting service data, removing
 containers with volumes, or rewriting persisted Flexo startup data, get

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -653,5 +653,285 @@ class CliTests(unittest.TestCase):
             self.assertIn("dirty Flexo startup dataset: deploy/flexo-mms/mount/cluster.trig", issues)
 
 
+class SysonPasswordTests(unittest.TestCase):
+    """Tests for issue #10: Generate random SysON Postgres password during init/bootstrap."""
+
+    def test_ensure_syson_env_generates_random_password_not_placeholder(self) -> None:
+        from mbse_lab.workspace import SYSON_POSTGRES_PASSWORD_PLACEHOLDER, ensure_syson_env
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            example = repo / "deploy/syson/.env.example"
+            example.parent.mkdir(parents=True)
+            example.write_text(
+                f"SYSON_POSTGRES_PASSWORD={SYSON_POSTGRES_PASSWORD_PLACEHOLDER}\n",
+                encoding="utf-8",
+            )
+
+            ensure_syson_env(repo)
+
+            env_path = repo / "deploy/syson/.env"
+            self.assertTrue(env_path.exists())
+            env_content = env_path.read_text(encoding="utf-8")
+            self.assertNotIn(SYSON_POSTGRES_PASSWORD_PLACEHOLDER, env_content)
+            self.assertIn("SYSON_POSTGRES_PASSWORD=", env_content)
+
+    def test_ensure_syson_env_preserves_existing_env(self) -> None:
+        from mbse_lab.workspace import ensure_syson_env
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            env_path = repo / "deploy/syson/.env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("SYSON_POSTGRES_PASSWORD=my-custom-password\n", encoding="utf-8")
+
+            ensure_syson_env(repo)
+
+            self.assertEqual(env_path.read_text(encoding="utf-8"), "SYSON_POSTGRES_PASSWORD=my-custom-password\n")
+
+    def test_doctor_flags_placeholder_password(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            env_path = repo / "deploy/syson/.env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("SYSON_POSTGRES_PASSWORD=change-me\n", encoding="utf-8")
+
+            with mock.patch.object(health, "has_persisted_data", return_value=True):
+                report = health.syson_database_credential_report(repo)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(report["status"], "placeholder-password")
+        self.assertIn("placeholder", report["detail"])
+
+    def test_doctor_report_includes_syson_password_placeholder_remediation_code(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            env_path = repo / "deploy/syson/.env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("SYSON_POSTGRES_PASSWORD=change-me\n", encoding="utf-8")
+
+            with (
+                mock.patch.object(health, "has_persisted_data", return_value=True),
+                mock.patch.object(health, "command_exists", return_value=True),
+                mock.patch.object(health, "tcp_connects", return_value=False),
+                mock.patch.object(health, "fetch_status", return_value=None),
+                mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+            ):
+                report = health.doctor_report(repo)
+
+        self.assertIn("SYSON_PASSWORD_PLACEHOLDER", report["remediation_codes"])
+
+
+class WorkspacePreflightTests(unittest.TestCase):
+    """Tests for issue #11: Private workspace preflight for generated artifacts."""
+
+    def test_warn_when_workspace_unset_and_no_explicit_output(self) -> None:
+        self.assertTrue(cli.should_warn_repo_local_exports(None, allow_repo_exports=False))
+
+    def test_no_warn_when_explicit_output_given(self) -> None:
+        self.assertFalse(cli.should_warn_repo_local_exports(Path("/some/output"), allow_repo_exports=False))
+
+    def test_no_warn_when_allow_repo_exports_set(self) -> None:
+        self.assertFalse(cli.should_warn_repo_local_exports(None, allow_repo_exports=True))
+
+    def test_no_warn_when_workspace_env_is_set(self) -> None:
+        with mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": "/some/workspace"}):
+            self.assertFalse(cli.should_warn_repo_local_exports(None, allow_repo_exports=False))
+
+    def test_first_model_dry_run_no_warning_with_allow_repo_exports(self) -> None:
+        runner = CliRunner()
+        with mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": ""}):
+            result = runner.invoke(
+                cli.main,
+                ["--repo-root", str(ROOT), "first-model", "Demo", "--dry-run", "--allow-repo-exports"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("warning: MBSE_MODEL_WORKSPACE is unset", result.output)
+
+    def test_flexo_export_warns_when_workspace_unset(self) -> None:
+        runner = CliRunner()
+        with mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": ""}):
+            result = runner.invoke(
+                cli.main,
+                ["--repo-root", str(ROOT), "flexo", "export", "proj-1", "--dry-run"],
+            )
+
+        self.assertIn("warning: MBSE_MODEL_WORKSPACE is unset", result.output)
+
+    def test_flexo_export_no_warning_with_allow_repo_exports(self) -> None:
+        runner = CliRunner()
+        with mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": ""}):
+            result = runner.invoke(
+                cli.main,
+                ["--repo-root", str(ROOT), "flexo", "export", "proj-1", "--dry-run", "--allow-repo-exports"],
+            )
+
+        self.assertNotIn("warning: MBSE_MODEL_WORKSPACE is unset", result.output)
+
+    def test_bridge_render_warns_when_workspace_unset(self) -> None:
+        runner = CliRunner()
+        with mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": ""}):
+            result = runner.invoke(
+                cli.main,
+                ["--repo-root", str(ROOT), "bridge", "render", "export.json", "--dry-run"],
+            )
+
+        self.assertIn("warning: MBSE_MODEL_WORKSPACE is unset", result.output)
+
+    def test_bridge_run_no_warning_with_explicit_output_dir(self) -> None:
+        runner = CliRunner()
+        with mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": ""}):
+            result = runner.invoke(
+                cli.main,
+                [
+                    "--repo-root",
+                    str(ROOT),
+                    "bridge",
+                    "run",
+                    "flexo-proj",
+                    "--syson-project-id",
+                    "syson-proj",
+                    "--namespace-id",
+                    "ns-1",
+                    "--output-dir",
+                    "/tmp/explicit-output",
+                    "--dry-run",
+                ],
+            )
+
+        self.assertNotIn("warning: MBSE_MODEL_WORKSPACE is unset", result.output)
+
+
+class DoctorRemediationCodesTests(unittest.TestCase):
+    """Tests for issue #14: Remediation codes and grouped next steps in doctor."""
+
+    def test_doctor_report_includes_remediation_codes_key(self) -> None:
+        with (
+            mock.patch.object(health, "command_exists", return_value=True),
+            mock.patch.object(health, "tcp_connects", return_value=False),
+            mock.patch.object(health, "fetch_status", return_value=None),
+            mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+        ):
+            report = health.doctor_report(None)
+
+        self.assertIn("remediation_codes", report)
+        self.assertIsInstance(report["remediation_codes"], list)
+
+    def test_doctor_report_includes_repo_root_missing_code(self) -> None:
+        with (
+            mock.patch.object(health, "command_exists", return_value=True),
+            mock.patch.object(health, "tcp_connects", return_value=False),
+            mock.patch.object(health, "fetch_status", return_value=None),
+            mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+        ):
+            report = health.doctor_report(None)
+
+        self.assertIn("REPO_ROOT_MISSING", report["remediation_codes"])
+
+    def test_doctor_report_includes_workspace_unset_code(self) -> None:
+        with (
+            mock.patch.object(health, "command_exists", return_value=True),
+            mock.patch.object(health, "tcp_connects", return_value=False),
+            mock.patch.object(health, "fetch_status", return_value=None),
+            mock.patch.dict(os.environ, {"MBSE_MODEL_WORKSPACE": ""}),
+            mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+        ):
+            report = health.doctor_report(None)
+
+        self.assertIn("WORKSPACE_UNSET", report["remediation_codes"])
+
+    def test_doctor_json_output_includes_remediation_codes(self) -> None:
+        runner = CliRunner()
+        mock_report = {
+            "status": "passed",
+            "checks": {
+                "repo_root": {"ok": True, "path": str(ROOT)},
+                "markers": [],
+            },
+            "remediation_codes": ["WORKSPACE_UNSET"],
+        }
+        with mock.patch.object(cli, "doctor_report", return_value=mock_report):
+            result = runner.invoke(cli.main, ["--repo-root", str(ROOT), "doctor", "--json-output"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        report = json.loads(result.output)
+        self.assertIn("remediation_codes", report)
+        self.assertIn("WORKSPACE_UNSET", report["remediation_codes"])
+
+    def test_doctor_text_output_has_grouped_sections(self) -> None:
+        runner = CliRunner()
+        with (
+            mock.patch.object(cli, "command_exists", return_value=True),
+            mock.patch.object(cli, "tcp_connects", return_value=False),
+            mock.patch.object(cli, "fetch_status", return_value=None),
+            mock.patch.object(cli.subprocess, "run", return_value=mock.Mock(returncode=0)),
+            mock.patch.object(
+                cli,
+                "doctor_report",
+                return_value={
+                    "status": "passed",
+                    "checks": {
+                        "syson_database_credentials": {"ok": True, "detail": "skipped", "status": "skipped"}
+                    },
+                    "remediation_codes": [],
+                },
+            ),
+        ):
+            result = runner.invoke(cli.main, ["--repo-root", str(ROOT), "doctor"])
+
+        self.assertIn("--- Prerequisites ---", result.output)
+        self.assertIn("--- Repo Setup ---", result.output)
+        self.assertIn("--- Workspace ---", result.output)
+        self.assertIn("--- Services ---", result.output)
+
+
+class DocsCheckMbseLabCommandsTests(unittest.TestCase):
+    """Tests for issue #12: docs-check validates mbse-lab command snippets."""
+
+    def test_valid_mbse_lab_commands_in_docs_pass(self) -> None:
+        import importlib.util
+        import sys as _sys
+
+        spec = importlib.util.spec_from_file_location(
+            "check_docs", ROOT / "scripts" / "check_docs.py"
+        )
+        check_docs = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(check_docs)
+
+        failures: list[str] = []
+        check_docs.check_mbse_lab_commands(failures)
+        self.assertEqual(failures, [], f"Unexpected failures: {failures}")
+
+    def test_stale_mbse_lab_command_fails_docs_check(self) -> None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "check_docs", ROOT / "scripts" / "check_docs.py"
+        )
+        check_docs = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(check_docs)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", dir=ROOT / "docs", delete=False, encoding="utf-8"
+        ) as tmp_doc:
+            tmp_doc.write("# Test\n\n```bash\nmbse-lab nonexistent-command-xyz\n```\n")
+            tmp_path = Path(tmp_doc.name)
+
+        try:
+            with mock.patch.object(
+                check_docs, "tracked_and_untracked_docs", return_value=[tmp_path]
+            ):
+                failures: list[str] = []
+                check_docs.check_mbse_lab_commands(failures)
+
+            self.assertTrue(
+                any("nonexistent-command-xyz" in f for f in failures),
+                f"Expected failure for stale command, got: {failures}",
+            )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -563,7 +563,7 @@ class CliTests(unittest.TestCase):
             cli.run_capture(["git", "config", "user.name", "Test User"], repo)
             env = repo / "deploy" / "syson" / ".env"
             env.parent.mkdir(parents=True)
-            env.write_text("SYSON_POSTGRES_PASSWORD=pass" "word\n", encoding="utf-8")
+            env.write_text("SYSON_POSTGRES_PASSWORD=pass" "word\n", encoding="utf-8")  # fmt: skip
             cli.run_capture(["git", "add", "-f", "deploy/syson/.env"], repo)
 
             issues = cli.scan_share_issues(repo)
@@ -876,9 +876,7 @@ class DoctorRemediationCodesTests(unittest.TestCase):
                 "doctor_report",
                 return_value={
                     "status": "passed",
-                    "checks": {
-                        "syson_database_credentials": {"ok": True, "detail": "skipped", "status": "skipped"}
-                    },
+                    "checks": {"syson_database_credentials": {"ok": True, "detail": "skipped", "status": "skipped"}},
                     "remediation_codes": [],
                 },
             ),
@@ -896,11 +894,8 @@ class DocsCheckMbseLabCommandsTests(unittest.TestCase):
 
     def test_valid_mbse_lab_commands_in_docs_pass(self) -> None:
         import importlib.util
-        import sys as _sys
 
-        spec = importlib.util.spec_from_file_location(
-            "check_docs", ROOT / "scripts" / "check_docs.py"
-        )
+        spec = importlib.util.spec_from_file_location("check_docs", ROOT / "scripts" / "check_docs.py")
         check_docs = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(check_docs)
 
@@ -911,9 +906,7 @@ class DocsCheckMbseLabCommandsTests(unittest.TestCase):
     def test_stale_mbse_lab_command_fails_docs_check(self) -> None:
         import importlib.util
 
-        spec = importlib.util.spec_from_file_location(
-            "check_docs", ROOT / "scripts" / "check_docs.py"
-        )
+        spec = importlib.util.spec_from_file_location("check_docs", ROOT / "scripts" / "check_docs.py")
         check_docs = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(check_docs)
 
@@ -924,9 +917,7 @@ class DocsCheckMbseLabCommandsTests(unittest.TestCase):
             tmp_path = Path(tmp_doc.name)
 
         try:
-            with mock.patch.object(
-                check_docs, "tracked_and_untracked_docs", return_value=[tmp_path]
-            ):
+            with mock.patch.object(check_docs, "tracked_and_untracked_docs", return_value=[tmp_path]):
                 failures: list[str] = []
                 check_docs.check_mbse_lab_commands(failures)
 

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -663,8 +663,13 @@ class SysonPasswordTests(unittest.TestCase):
             repo = Path(temp_dir)
             example = repo / "deploy/syson/.env.example"
             example.parent.mkdir(parents=True)
+            # Write a minimal .env.example using the real placeholder text so ensure_syson_env
+            # replaces it with a generated value.
             example.write_text(
-                f"SYSON_POSTGRES_PASSWORD={SYSON_POSTGRES_PASSWORD_PLACEHOLDER}\n",
+                "SYSON_POSTGRES_IMAGE=postgres:15\n"
+                "SYSON_POSTGRES_DB=postgres\n"
+                "SYSON_POSTGRES_USER=username\n"
+                "SYSON_POSTGRES_PASSWORD=change-me\n",
                 encoding="utf-8",
             )
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -150,8 +150,7 @@ def check_discoverability(failures: list[str]) -> None:
             continue
         if relative not in linked_paths:
             fail(
-                f"{relative} is not linked from README.md, WORKFLOW.md, AGENTS.md, "
-                "docs/index.md, or harness guidance",
+                f"{relative} is not linked from README.md, WORKFLOW.md, AGENTS.md, docs/index.md, or harness guidance",
                 failures,
             )
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -104,6 +104,7 @@ def command_blocks(path: Path) -> list[str]:
                 in_fence = False
                 fence_language = ""
             continue
+        # Process bash, sh, shell, and unfenced (empty language tag) code blocks.
         if not in_fence or fence_language not in {"bash", "sh", "shell", ""}:
             continue
         stripped = line.strip()
@@ -129,6 +130,7 @@ def code_block_lines(path: Path) -> list[str]:
                 in_fence = False
                 fence_language = ""
             continue
+        # Process bash, sh, shell, and unfenced (empty language tag) code blocks.
         if not in_fence or fence_language not in {"bash", "sh", "shell", ""}:
             continue
         stripped = line.strip()

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -31,8 +32,11 @@ MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 MBSE_LAB_COMMAND = re.compile(r"(?:^|\s)mbse-lab\s+([A-Za-z0-9_-]+(?:\s+[A-Za-z0-9_-]+)?)")
 
 
-def run(command: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, cwd=ROOT, text=True, capture_output=True)
+def run(command: list[str], extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = None
+    if extra_env:
+        env = {**os.environ, **extra_env}
+    return subprocess.run(command, cwd=ROOT, text=True, capture_output=True, env=env)
 
 
 def fail(message: str, failures: list[str]) -> None:
@@ -186,7 +190,11 @@ def check_python_commands(failures: list[str]) -> None:
 
 def mbse_lab_top_level_commands() -> set[str]:
     """Return the set of top-level mbse-lab command/group names from --help."""
-    result = run(["python3", "-m", "mbse_lab.cli", "--help"])
+    python_path = str(ROOT / "src")
+    existing_python_path = os.environ.get("PYTHONPATH")
+    if existing_python_path:
+        python_path = f"{python_path}{os.pathsep}{existing_python_path}"
+    result = run([sys.executable, "-m", "mbse_lab.cli", "--help"], {"PYTHONPATH": python_path})
     text = result.stdout + result.stderr
     commands: set[str] = set()
     in_commands = False

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -28,6 +28,7 @@ COMMAND_LINE = re.compile(r"^\s*(?:[A-Z0-9_./-]+=\\S+\s+)*(make|python3|docker|c
 PYTHON_SCRIPT = re.compile(r"python3\s+(scripts/[A-Za-z0-9_.\-/]+\.py)(?:\s+([A-Za-z0-9_-]+))?")
 MAKE_TARGET = re.compile(r"\bmake\s+([A-Za-z0-9_.-]+)")
 MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+MBSE_LAB_COMMAND = re.compile(r"(?:^|\s)mbse-lab\s+([A-Za-z0-9_-]+(?:\s+[A-Za-z0-9_-]+)?)")
 
 
 def run(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -113,6 +114,30 @@ def command_blocks(path: Path) -> list[str]:
     return commands
 
 
+def code_block_lines(path: Path) -> list[str]:
+    """Return all non-empty, non-comment lines from bash code blocks."""
+    text = path.read_text(encoding="utf-8")
+    lines: list[str] = []
+    in_fence = False
+    fence_language = ""
+    for line in text.splitlines():
+        if line.startswith("```"):
+            if not in_fence:
+                in_fence = True
+                fence_language = line.removeprefix("```").strip()
+            else:
+                in_fence = False
+                fence_language = ""
+            continue
+        if not in_fence or fence_language not in {"bash", "sh", "shell", ""}:
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.endswith("\\"):
+            continue
+        lines.append(stripped)
+    return lines
+
+
 def check_discoverability(failures: list[str]) -> None:
     linked_paths = linked_index_paths()
     for path in tracked_and_untracked_docs():
@@ -158,6 +183,45 @@ def check_python_commands(failures: list[str]) -> None:
                     )
 
 
+def mbse_lab_top_level_commands() -> set[str]:
+    """Return the set of top-level mbse-lab command/group names from --help."""
+    result = run(["python3", "-m", "mbse_lab.cli", "--help"])
+    text = result.stdout + result.stderr
+    commands: set[str] = set()
+    in_commands = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if re.match(r"^Commands:$", stripped, re.IGNORECASE):
+            in_commands = True
+            continue
+        if in_commands:
+            if not stripped:
+                break
+            match = re.match(r"^([A-Za-z0-9_-]+)", stripped)
+            if match:
+                commands.add(match.group(1))
+    return commands
+
+
+def check_mbse_lab_commands(failures: list[str]) -> None:
+    top_level = mbse_lab_top_level_commands()
+    if not top_level:
+        return
+    for doc in tracked_and_untracked_docs():
+        for line in code_block_lines(doc):
+            for match in MBSE_LAB_COMMAND.finditer(line):
+                tokens = match.group(1).split()
+                first_token = tokens[0]
+                if first_token.startswith("-"):
+                    continue
+                if first_token not in top_level:
+                    fail(
+                        f"{doc.relative_to(ROOT)} references `mbse-lab {first_token}`, "
+                        "but that command is not in `mbse-lab --help`",
+                        failures,
+                    )
+
+
 def check_workflow_contract(failures: list[str]) -> None:
     if not WORKFLOW_FILE.exists():
         fail("WORKFLOW.md is missing", failures)
@@ -195,6 +259,7 @@ def validate_docs() -> list[str]:
     check_discoverability(failures)
     check_make_commands(failures)
     check_python_commands(failures)
+    check_mbse_lab_commands(failures)
     failures.extend(validate_workflow())
     return failures
 

--- a/src/mbse_lab/cli.py
+++ b/src/mbse_lab/cli.py
@@ -61,8 +61,8 @@ __all__ = (
 )
 
 
-def should_warn_repo_local_exports(explicit_output: Path | None) -> bool:
-    return explicit_output is None and not os.environ.get(MODEL_WORKSPACE_ENV)
+def should_warn_repo_local_exports(explicit_output: Path | None, allow_repo_exports: bool = False) -> bool:
+    return not allow_repo_exports and explicit_output is None and not os.environ.get(MODEL_WORKSPACE_ENV)
 
 
 def warn_repo_local_exports(output_dir: Path) -> None:
@@ -70,7 +70,8 @@ def warn_repo_local_exports(output_dir: Path) -> None:
         (
             f"warning: {MODEL_WORKSPACE_ENV} is unset; generated model artifacts "
             f"will be written under repo-local `{output_dir}`. Set {MODEL_WORKSPACE_ENV} "
-            "or pass an explicit output path for private model data."
+            "or pass an explicit output path for private model data. "
+            "Pass --allow-repo-exports to suppress this warning."
         ),
         err=True,
     )
@@ -337,6 +338,11 @@ def bootstrap(
 @click.option("--timeout", type=int, default=30, show_default=True)
 @click.option("--json-output", is_flag=True, help="Print a machine-readable JSON summary.")
 @click.option("--dry-run", is_flag=True, help="Print the planned workflow without creating projects.")
+@click.option(
+    "--allow-repo-exports",
+    is_flag=True,
+    help="Suppress the warning when MBSE_MODEL_WORKSPACE is unset and writing to repo-local exports/.",
+)
 @click.pass_context
 def first_model(
     ctx: click.Context,
@@ -349,13 +355,14 @@ def first_model(
     timeout: int,
     json_output: bool,
     dry_run: bool,
+    allow_repo_exports: bool,
 ) -> None:
     """Create a tiny Flexo model and import it into a SysON review project."""
     repo_root = require_repo_root(ctx)
     resolved_package_name = package_name or name
     resolved_syson_project_name = syson_project_name or f"{name} Review"
     resolved_output_dir = (output_dir or default_output_dir()).expanduser()
-    if should_warn_repo_local_exports(output_dir):
+    if should_warn_repo_local_exports(output_dir, allow_repo_exports):
         warn_repo_local_exports(resolved_output_dir)
     package_identifier = sanitize_identifier(resolved_package_name)
 
@@ -477,8 +484,10 @@ def doctor(ctx: click.Context, json_output: bool, fix: bool) -> None:
 
     failures = 0
 
-    check_mark("python", command_exists("python3"), sys.version.split()[0])
-    if not command_exists("python3"):
+    click.echo("--- Prerequisites ---")
+    python_ok = command_exists("python3")
+    check_mark("python", python_ok, sys.version.split()[0])
+    if not python_ok:
         failures += 1
 
     docker_ok = command_exists("docker")
@@ -491,6 +500,8 @@ def doctor(ctx: click.Context, json_output: bool, fix: bool) -> None:
         check_mark("docker compose", False)
         failures += 1
 
+    click.echo("")
+    click.echo("--- Repo Setup ---")
     if repo_root:
         check_mark("repo root", True, str(repo_root))
         for marker in REQUIRED_MARKERS:
@@ -499,11 +510,13 @@ def doctor(ctx: click.Context, json_output: bool, fix: bool) -> None:
             if not exists:
                 failures += 1
         warn_mark("Flexo env", (repo_root / "deploy/flexo-mms/.env").exists(), "run `make init` if missing")
-        warn_mark("SysON env", (repo_root / "deploy/syson/.env").exists(), "copy deploy/syson/.env.example if missing")
+        warn_mark("SysON env", (repo_root / "deploy/syson/.env").exists(), "run `mbse-lab init` if missing")
     else:
         check_mark("repo root", False, "run from the repo or pass --repo-root")
         failures += 1
 
+    click.echo("")
+    click.echo("--- Workspace ---")
     workspace = os.environ.get("MBSE_MODEL_WORKSPACE")
     if workspace:
         workspace_path = Path(workspace).expanduser()
@@ -511,6 +524,8 @@ def doctor(ctx: click.Context, json_output: bool, fix: bool) -> None:
     else:
         warn_mark("MBSE_MODEL_WORKSPACE", False, "unset; generated artifacts default to exports/")
 
+    click.echo("")
+    click.echo("--- Services ---")
     for label, port in (
         ("Flexo SysML v2 port", 18083),
         ("SysON web port", 18090),
@@ -531,6 +546,13 @@ def doctor(ctx: click.Context, json_output: bool, fix: bool) -> None:
             bool(syson_database_credentials.get("ok")),
             str(syson_database_credentials.get("detail", "")),
         )
+
+    remediation_codes = report.get("remediation_codes", [])
+    if remediation_codes:
+        click.echo("")
+        click.echo("--- Remediation Codes ---")
+        for code in remediation_codes:
+            click.echo(f"  {code}")
 
     if failures:
         raise click.ClickException(f"doctor found {failures} required failure(s)")
@@ -739,6 +761,11 @@ def flexo_create(
 @click.option("--flexo-url", default=DEFAULT_FLEXO_URL, show_default=True)
 @click.option("--timeout", type=int, default=30, show_default=True)
 @click.option("--dry-run", is_flag=True)
+@click.option(
+    "--allow-repo-exports",
+    is_flag=True,
+    help="Suppress the warning when MBSE_MODEL_WORKSPACE is unset and writing to repo-local exports/.",
+)
 @click.pass_context
 def flexo_export(
     ctx: click.Context,
@@ -748,10 +775,11 @@ def flexo_export(
     flexo_url: str,
     timeout: int,
     dry_run: bool,
+    allow_repo_exports: bool,
 ) -> None:
     """Export a Flexo project snapshot."""
     args = ["flexo-export", project_id, "--flexo-url", flexo_url, "--timeout", str(timeout)]
-    if dry_run and should_warn_repo_local_exports(output):
+    if should_warn_repo_local_exports(output, allow_repo_exports):
         warn_repo_local_exports(default_output_dir())
     if commit_id:
         args.extend(["--commit-id", commit_id])
@@ -835,11 +863,16 @@ def bridge() -> None:
 @click.argument("input", type=click.Path(path_type=Path, exists=False))
 @click.option("--output", type=click.Path(path_type=Path))
 @click.option("--dry-run", is_flag=True)
+@click.option(
+    "--allow-repo-exports",
+    is_flag=True,
+    help="Suppress the warning when MBSE_MODEL_WORKSPACE is unset and writing to repo-local exports/.",
+)
 @click.pass_context
-def bridge_render(ctx: click.Context, input: Path, output: Path | None, dry_run: bool) -> None:
+def bridge_render(ctx: click.Context, input: Path, output: Path | None, dry_run: bool, allow_repo_exports: bool) -> None:
     """Render a Flexo export JSON file as SysML textual notation."""
     args = ["render-sysml", str(input)]
-    if dry_run and should_warn_repo_local_exports(output):
+    if should_warn_repo_local_exports(output, allow_repo_exports):
         warn_repo_local_exports(default_output_dir())
     if output:
         args.extend(["--output", str(output)])
@@ -896,6 +929,11 @@ def bridge_import(
 @click.option("--syson-url", default=DEFAULT_SYSON_URL, show_default=True)
 @click.option("--timeout", type=int, default=30, show_default=True)
 @click.option("--dry-run", is_flag=True)
+@click.option(
+    "--allow-repo-exports",
+    is_flag=True,
+    help="Suppress the warning when MBSE_MODEL_WORKSPACE is unset and writing to repo-local exports/.",
+)
 @click.pass_context
 def bridge_run(
     ctx: click.Context,
@@ -911,9 +949,10 @@ def bridge_run(
     syson_url: str,
     timeout: int,
     dry_run: bool,
+    allow_repo_exports: bool,
 ) -> None:
     """Export from Flexo, render SysML text, and import into SysON."""
-    if dry_run and should_warn_repo_local_exports(output_dir):
+    if should_warn_repo_local_exports(output_dir, allow_repo_exports):
         warn_repo_local_exports(default_output_dir())
     args = [
         "flexo-to-syson",

--- a/src/mbse_lab/cli.py
+++ b/src/mbse_lab/cli.py
@@ -869,7 +869,9 @@ def bridge() -> None:
     help="Suppress the warning when MBSE_MODEL_WORKSPACE is unset and writing to repo-local exports/.",
 )
 @click.pass_context
-def bridge_render(ctx: click.Context, input: Path, output: Path | None, dry_run: bool, allow_repo_exports: bool) -> None:
+def bridge_render(
+    ctx: click.Context, input: Path, output: Path | None, dry_run: bool, allow_repo_exports: bool
+) -> None:
     """Render a Flexo export JSON file as SysML textual notation."""
     args = ["render-sysml", str(input)]
     if should_warn_repo_local_exports(output, allow_repo_exports):

--- a/src/mbse_lab/health.py
+++ b/src/mbse_lab/health.py
@@ -22,6 +22,8 @@ from mbse_lab.constants import (
 from mbse_lab.http import fetch_status
 from mbse_lab.shell import run_capture_result
 
+SYSON_POSTGRES_PASSWORD_PLACEHOLDER = "change-me"
+
 
 def check_mark(label: str, ok: bool, detail: str = "") -> None:
     status = "ok" if ok else "fail"
@@ -125,6 +127,18 @@ def syson_database_credential_report(repo_root: Path) -> dict[str, object]:
 
     if not env_path.exists():
         report.update({"status": "missing-env", "detail": "deploy/syson/.env does not exist."})
+        return report
+    if password == SYSON_POSTGRES_PASSWORD_PLACEHOLDER:
+        report.update(
+            {
+                "ok": False,
+                "status": "placeholder-password",
+                "detail": (
+                    "SYSON_POSTGRES_PASSWORD in deploy/syson/.env is still the placeholder value. "
+                    "Run `mbse-lab init` or set a strong password before starting SysON."
+                ),
+            }
+        )
         return report
     if not data_exists:
         report.update({"status": "no-data", "detail": "No persisted SysON Postgres data found."})
@@ -257,7 +271,37 @@ def doctor_report(repo_root: Path | None) -> dict[str, object]:
         and checks["repo_root"]["ok"]
         and all(marker["exists"] for marker in markers)
     )
+
+    remediation_codes: list[str] = []
+    if not checks["python"]["ok"]:
+        remediation_codes.append("PYTHON_MISSING")
+    if not checks["docker"]["ok"]:
+        remediation_codes.append("DOCKER_MISSING")
+    if not checks["docker_compose"]["ok"]:
+        remediation_codes.append("DOCKER_COMPOSE_MISSING")
+    if not checks["repo_root"]["ok"]:
+        remediation_codes.append("REPO_ROOT_MISSING")
+    for marker in markers:
+        if not marker["exists"]:
+            remediation_codes.append(f"MARKER_MISSING:{marker['path']}")
+    if not checks["flexo_env"]["ok"]:
+        remediation_codes.append("FLEXO_ENV_MISSING")
+    if not checks["syson_env"]["ok"]:
+        remediation_codes.append("SYSON_ENV_MISSING")
+    syson_db = checks.get("syson_database_credentials")
+    if isinstance(syson_db, dict) and syson_db.get("status") == "placeholder-password":
+        remediation_codes.append("SYSON_PASSWORD_PLACEHOLDER")
+    if not workspace:
+        remediation_codes.append("WORKSPACE_UNSET")
+    elif workspace_path and not workspace_path.exists():
+        remediation_codes.append("WORKSPACE_MISSING")
+    if not checks["ports"]["flexo_sysmlv2"]["ok"]:
+        remediation_codes.append("FLEXO_UNREACHABLE")
+    if not checks["ports"]["syson_web"]["ok"]:
+        remediation_codes.append("SYSON_UNREACHABLE")
+
     return {
         "status": "passed" if required_ok else "failed",
         "checks": checks,
+        "remediation_codes": remediation_codes,
     }

--- a/src/mbse_lab/workspace.py
+++ b/src/mbse_lab/workspace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import secrets
 import shutil
 from pathlib import Path
 
@@ -11,6 +12,8 @@ import click
 
 from mbse_lab.constants import WORKSPACE_DIRS
 from mbse_lab.shell import run_command
+
+SYSON_POSTGRES_PASSWORD_PLACEHOLDER = "change-me"
 
 
 def default_output_dir() -> Path:
@@ -29,6 +32,16 @@ def sanitize_identifier(value: str) -> str:
     return value
 
 
+def _generate_syson_env_content(example_path: Path) -> str:
+    """Read the example env file and replace the placeholder password with a random one."""
+    template = example_path.read_text(encoding="utf-8")
+    random_password = secrets.token_urlsafe(24)
+    return template.replace(
+        f"SYSON_POSTGRES_PASSWORD={SYSON_POSTGRES_PASSWORD_PLACEHOLDER}",
+        f"SYSON_POSTGRES_PASSWORD={random_password}",
+    )
+
+
 def ensure_syson_env(repo_root: Path, dry_run: bool = False) -> None:
     env_path = repo_root / "deploy/syson/.env"
     example_path = repo_root / "deploy/syson/.env.example"
@@ -40,8 +53,9 @@ def ensure_syson_env(repo_root: Path, dry_run: bool = False) -> None:
     if dry_run:
         click.echo(f"dry-run: copy {example_path.relative_to(repo_root)} to {env_path.relative_to(repo_root)}")
         return
-    shutil.copyfile(example_path, env_path)
-    click.echo(f"Created SysON env: {env_path.relative_to(repo_root)}")
+    env_content = _generate_syson_env_content(example_path)
+    env_path.write_text(env_content, encoding="utf-8")
+    click.echo(f"Created SysON env with generated password: {env_path.relative_to(repo_root)}")
 
 
 def initialize_model_workspace(root: Path, force: bool, git_init: bool, dry_run: bool = False) -> Path:

--- a/src/mbse_lab/workspace.py
+++ b/src/mbse_lab/workspace.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import re
 import secrets
-import shutil
 from pathlib import Path
 
 import click

--- a/src/mbse_lab/workspace.py
+++ b/src/mbse_lab/workspace.py
@@ -33,7 +33,7 @@ def sanitize_identifier(value: str) -> str:
 
 
 def _generate_syson_env_content(example_path: Path) -> str:
-    """Read the example env file and replace the placeholder password with a random one."""
+    """Read the example env file, replace the placeholder password with a random one, and return the modified content."""
     template = example_path.read_text(encoding="utf-8")
     random_password = secrets.token_urlsafe(24)
     return template.replace(


### PR DESCRIPTION
## Summary

- replaces PR #35 with a Git Flow compliant `feature/*` branch
- carries the first-use hardening changes for SysON password generation, workspace export preflight, docs-check CLI validation, and doctor remediation codes
- fixes the failing docs-check CLI discovery test by running `mbse_lab.cli --help` with `src/` on `PYTHONPATH`

## PR #35 Review Notes

- Branch policy failed because `copilot/sprint-plan-first-use-workflow-harden` does not match the allowed `feature/*` pattern for `develop`.
- Repository validation failed in `test_stale_mbse_lab_command_fails_docs_check` because `scripts/check_docs.py` could not discover `mbse_lab.cli` in CI without `PYTHONPATH=src`.

## Validation

- `python3 -m unittest evals.test_bridge_cli.DocsCheckMbseLabCommandsTests`
- `make docs-check`
- `pre-commit run --all-files`
- `make check`

Note: local validation temporarily set aside an unrelated untracked `docs/reviews/recommended-sprints.md`; it is not part of this PR.

Refs #10, #11, #12, #14.
Replaces #35.