### PR TITLE
[codex] Evaluate View Editor Flexo compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ docs/user-guide/private-model-workspaces.md
 docs/lab/flexo-syson-bridge.md   Bridge-specific notes
 docs/lab/harness-engineering.md   Harness design and eval/diagnostics guidance
 docs/lab/modeling-conventions.md  Supported SysML v2 rendering subset
+docs/lab/view-editor-flexo-experiment.md
+                                  View Editor compatibility evidence
 docs/methodology/                 Reusable SysML v2 method guidance
 docs/model-specs/                 General-purpose model specifications
 docs/plans/README.md              Execution plan conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ deploy/syson/docker-compose.yml
 deploy/syson/README.md            SysON deployment-specific operations
 deploy/view-editor/docker-compose.yml
 deploy/view-editor/README.md      Experimental View Editor compatibility probe
+deploy/view-editor-5/docker-compose.yml
+deploy/view-editor-5/README.md    Source-built View Editor 5.x experiment
 scripts/flexo_mms_env.py          Flexo environment manager
 scripts/flexo_syson_bridge.py     Flexo/SysON bridge CLI
 Makefile                          Stable command targets for routine workflows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ deploy/flexo-mms/docker-compose.yml
 deploy/flexo-mms/README.md        Flexo deployment-specific operations
 deploy/syson/docker-compose.yml
 deploy/syson/README.md            SysON deployment-specific operations
+deploy/view-editor/docker-compose.yml
+deploy/view-editor/README.md      Experimental View Editor compatibility probe
 scripts/flexo_mms_env.py          Flexo environment manager
 scripts/flexo_syson_bridge.py     Flexo/SysON bridge CLI
 Makefile                          Stable command targets for routine workflows

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ the full boundary.
 | [docs/index.md](docs/index.md) | Documentation landing page and task router. |
 | [docs/user-guide/](docs/user-guide/cli.md) | CLI, release, and private workspace guidance. |
 | [docs/lab/](docs/lab/flexo-syson-bridge.md) | Local lab operations, bridge behavior, and harness notes. |
+| [docs/lab/view-editor-flexo-experiment.md](docs/lab/view-editor-flexo-experiment.md) | View Editor compatibility evidence. |
 | [docs/methodology/](docs/methodology/sysml-v2-verification-model-setup.md) | Reusable SysML v2 setup and transformation guidance. |
 | [docs/model-specs/](docs/model-specs/rf-link-budget.md) | General-purpose model specifications. |
 | [docs/plans/](docs/plans/README.md) | Active and completed execution plans. |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ the full boundary.
 | [deploy/flexo-mms/](deploy/flexo-mms/README.md) | Flexo MMS Docker Compose environment. |
 | [deploy/syson/](deploy/syson/README.md) | SysON Docker Compose environment. |
 | [deploy/view-editor/](deploy/view-editor/README.md) | Experimental OpenMBEE View Editor compatibility probe. |
+| [deploy/view-editor-5/](deploy/view-editor-5/README.md) | Experimental source-built View Editor 5.x compatibility probe. |
 | [docs/index.md](docs/index.md) | Documentation landing page and task router. |
 | [docs/user-guide/](docs/user-guide/cli.md) | CLI, release, and private workspace guidance. |
 | [docs/lab/](docs/lab/flexo-syson-bridge.md) | Local lab operations, bridge behavior, and harness notes. |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ the full boundary.
 | --- | --- |
 | [deploy/flexo-mms/](deploy/flexo-mms/README.md) | Flexo MMS Docker Compose environment. |
 | [deploy/syson/](deploy/syson/README.md) | SysON Docker Compose environment. |
+| [deploy/view-editor/](deploy/view-editor/README.md) | Experimental OpenMBEE View Editor compatibility probe. |
 | [docs/index.md](docs/index.md) | Documentation landing page and task router. |
 | [docs/user-guide/](docs/user-guide/cli.md) | CLI, release, and private workspace guidance. |
 | [docs/lab/](docs/lab/flexo-syson-bridge.md) | Local lab operations, bridge behavior, and harness notes. |

--- a/deploy/view-editor-5/.dockerignore
+++ b/deploy/view-editor-5/.dockerignore
@@ -1,0 +1,4 @@
+*
+!Dockerfile
+!config/
+!nginx/

--- a/deploy/view-editor-5/Dockerfile
+++ b/deploy/view-editor-5/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:16-alpine AS builder
+
+ARG EXEC_VE_REPO=https://github.com/Open-MBEE/exec-ve.git
+ARG EXEC_VE_REF=5.0.0
+ARG VE_ENV=example
+ENV VE_ENV=${VE_ENV}
+
+WORKDIR /opt/mbee/ve
+
+RUN apk add --no-cache git openssh
+RUN git clone --depth 1 --branch "${EXEC_VE_REF}" "${EXEC_VE_REPO}" .
+RUN git config --global url."https://".insteadOf git://
+RUN yarn install
+RUN yarn webpack --config webpack.config.ts --mode=production --bail
+
+FROM nginx:mainline-alpine AS runtime
+
+ENV NGINX_PORT=80
+ENV VE_API_UPSTREAM=http://flexo-sysmlv2:8080
+
+COPY --from=builder /opt/mbee/ve/dist /usr/share/nginx/html
+COPY config/flexo-sysmlv2.json /usr/share/nginx/html/config/config.json
+COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
+
+EXPOSE 80

--- a/deploy/view-editor-5/README.md
+++ b/deploy/view-editor-5/README.md
@@ -1,0 +1,74 @@
+# OpenMBEE View Editor 5.x Experiment
+
+This directory contains an isolated source-build experiment for OpenMBEE View
+Editor 5.x. It exists to test the current View Editor source line against the
+local Flexo SysML v2 service without relying on the older published
+`openmbee/view-editor:3.6.1-omg` image.
+
+This is not a supported graphical workflow. Use synthetic or disposable model
+data only.
+
+## Build Path
+
+The Dockerfile clones `Open-MBEE/exec-ve` at tag `5.0.0`, installs the upstream
+Yarn dependencies, and builds the production webpack bundle directly:
+
+```text
+VE_ENV=example yarn webpack --config webpack.config.ts --mode=production --bail
+```
+
+It intentionally bypasses the upstream `prebuild` lint/format gate because the
+tagged source Dockerfile did not build cleanly during the experiment. The
+runtime stage serves the static bundle from nginx.
+
+## Runtime API Target
+
+The bundled config points View Editor at a same-origin API prefix:
+
+```text
+http://localhost:18092/api
+```
+
+nginx proxies `/api/` to the Flexo SysML v2 service on the shared Docker
+network:
+
+```text
+http://flexo-sysmlv2:8080/
+```
+
+This avoids browser CORS failures so request traces show Flexo API compatibility
+failures directly. If you change `VIEW_EDITOR_5_HOST_PORT`, update
+`config/flexo-sysmlv2.json` to keep `apiUrl` on the same host and port.
+
+## Run
+
+Start Flexo first so the shared Docker network exists:
+
+```bash
+python3 scripts/flexo_mms_env.py up --wait --timeout 60
+```
+
+Build and start View Editor 5.x:
+
+```bash
+docker compose -f deploy/view-editor-5/docker-compose.yml up -d --build
+```
+
+Open:
+
+```text
+http://localhost:18092/
+```
+
+Stop the experiment:
+
+```bash
+docker compose -f deploy/view-editor-5/docker-compose.yml down
+```
+
+## Expected Result
+
+The View Editor 5.x app should load, but Flexo SysML v2 is not expected to
+satisfy the MMS-style View Editor API contract. The key expected missing
+resources are authentication, auth check, org, ref, document/view, element,
+artifact, and search endpoints.

--- a/deploy/view-editor-5/config/flexo-sysmlv2.json
+++ b/deploy/view-editor-5/config/flexo-sysmlv2.json
@@ -1,0 +1,37 @@
+{
+  "apiUrl": "http://localhost:18092/api",
+  "printUrl": "http://localhost:8081/convert",
+  "basePath": "",
+  "enableDebug": false,
+  "customLabels": {
+    "pi": "PROPRIETARY: Proprietary Information",
+    "export_ctrl": "EXPORT WARNING: No export controlled documents allowed on this server",
+    "no_public_release": "Not for Public Release or Redistribution",
+    "unclassified": "CLASSIFICATION: This system is UNCLASSIFIED",
+    "opensource": "OpenMBEE View Editor 5.x Flexo experiment"
+  },
+  "loginBanner": {
+    "labels": [["unclassified"], ["pi"], ["no_public_release"]],
+    "separator": " ",
+    "background": "#0D47A1",
+    "color": "#e8e8e8"
+  },
+  "loginWarning": {
+    "message": [
+      "Experimental local View Editor 5.x deployment for Flexo compatibility tracing. Do not use with private model data."
+    ]
+  },
+  "banner": {
+    "labels": ["pi"]
+  },
+  "footer": {
+    "labels": ["opensource"]
+  },
+  "loginTimout": 600000,
+  "experimental": [
+    {
+      "id": "experimental-magic",
+      "name": "Content Magic"
+    }
+  ]
+}

--- a/deploy/view-editor-5/docker-compose.yml
+++ b/deploy/view-editor-5/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  view-editor-5:
+    build:
+      context: .
+      args:
+        EXEC_VE_REPO: "${VIEW_EDITOR_5_REPO:-https://github.com/Open-MBEE/exec-ve.git}"
+        EXEC_VE_REF: "${VIEW_EDITOR_5_REF:-5.0.0}"
+        VE_ENV: "${VIEW_EDITOR_5_BUILD_ENV:-example}"
+    image: "${VIEW_EDITOR_5_IMAGE:-mbse-view-editor:5.0.0-webpack-local}"
+    container_name: view-editor-5
+    environment:
+      NGINX_PORT: "80"
+      VE_API_UPSTREAM: "${VIEW_EDITOR_5_API_UPSTREAM:-http://flexo-sysmlv2:8080}"
+    ports:
+      - "${VIEW_EDITOR_5_HOST_PORT:-18092}:80"
+    networks:
+      - flexo
+
+networks:
+  flexo:
+    name: flexo-mms-test-network
+    external: true

--- a/deploy/view-editor-5/nginx/default.conf.template
+++ b/deploy/view-editor-5/nginx/default.conf.template
@@ -1,0 +1,22 @@
+server {
+    listen ${NGINX_PORT};
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /api {
+        return 308 /api/;
+    }
+
+    location /api/ {
+        proxy_pass ${VE_API_UPSTREAM}/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Forwarded-Proto http;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/view-editor/README.md
+++ b/deploy/view-editor/README.md
@@ -1,0 +1,67 @@
+# OpenMBEE View Editor Experiment
+
+This directory contains an isolated experiment for running the legacy published
+OpenMBEE View Editor image beside the local Flexo MMS stack.
+
+This is not a supported graphical workflow yet. Use it only to collect request
+traces for the View Editor/Flexo compatibility experiment.
+
+## Image
+
+The only public Docker Hub tag found during the experiment inventory was:
+
+```text
+openmbee/view-editor:3.6.1-omg
+```
+
+That image serves View Editor on container port `9000` and proxies `/alfresco`
+requests to the host and port configured by `VE_MMS_HOST` and `VE_MMS_PORT`.
+
+## Run
+
+Start Flexo first so the shared Docker network exists:
+
+```bash
+python3 scripts/flexo_mms_env.py up --wait --timeout 60
+```
+
+Start View Editor with the default Layer1 target:
+
+```bash
+docker compose -f deploy/view-editor/docker-compose.yml up -d
+```
+
+The published image rebuilds the bundled web assets when it starts, so the
+first useful HTTP response can lag container startup by a few seconds.
+
+Open:
+
+```text
+http://localhost:18091/
+```
+
+Stop the experiment:
+
+```bash
+docker compose -f deploy/view-editor/docker-compose.yml down
+```
+
+## Backend Targets
+
+The compose file defaults to the Flexo Layer1 service from inside Docker:
+
+```bash
+VIEW_EDITOR_MMS_HOST=layer1-service VIEW_EDITOR_MMS_PORT=8080 \
+  docker compose -f deploy/view-editor/docker-compose.yml up -d
+```
+
+To point the same image at the Flexo SysML v2 service:
+
+```bash
+VIEW_EDITOR_MMS_HOST=flexo-sysmlv2 VIEW_EDITOR_MMS_PORT=8080 \
+  docker compose -f deploy/view-editor/docker-compose.yml up -d
+```
+
+Expected result for the first spike is request evidence, not a successful user
+workflow. The View Editor image expects legacy MMS resources under `/alfresco`,
+including authentication, document, view, element, and search APIs.

--- a/deploy/view-editor/docker-compose.yml
+++ b/deploy/view-editor/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  view-editor:
+    image: "${VIEW_EDITOR_IMAGE:-openmbee/view-editor:3.6.1-omg}"
+    container_name: view-editor
+    environment:
+      VE_HOST: "${VIEW_EDITOR_HOST:-localhost}"
+      VE_MMS_HOST: "${VIEW_EDITOR_MMS_HOST:-layer1-service}"
+      VE_MMS_PORT: "${VIEW_EDITOR_MMS_PORT:-8080}"
+    ports:
+      - "${VIEW_EDITOR_HOST_PORT:-18091}:9000"
+    networks:
+      - flexo
+
+networks:
+  flexo:
+    name: flexo-mms-test-network
+    external: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ flowchart LR
 | [Bridge Workflow](lab/flexo-syson-bridge.md) | Exporting from Flexo, rendering textual SysML v2, and importing into SysON. |
 | [Harness Engineering](lab/harness-engineering.md) | Understanding command surfaces, guardrails, evals, diagnostics, and agent-oriented operating rules. |
 | [Modeling Conventions](lab/modeling-conventions.md) | Checking which Flexo element types are rendered into textual SysML v2 and how names are sanitized. |
+| [View Editor Flexo Experiment](lab/view-editor-flexo-experiment.md) | Request evidence and interim compatibility findings for the experimental OpenMBEE View Editor deployment. |
 
 ## Methodology
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ flowchart LR
 | [Bridge Workflow](lab/flexo-syson-bridge.md) | Exporting from Flexo, rendering textual SysML v2, and importing into SysON. |
 | [Harness Engineering](lab/harness-engineering.md) | Understanding command surfaces, guardrails, evals, diagnostics, and agent-oriented operating rules. |
 | [Modeling Conventions](lab/modeling-conventions.md) | Checking which Flexo element types are rendered into textual SysML v2 and how names are sanitized. |
-| [View Editor Flexo Experiment](lab/view-editor-flexo-experiment.md) | Request evidence and interim compatibility findings for the experimental OpenMBEE View Editor deployments. |
+| [View Editor Flexo Experiment](lab/view-editor-flexo-experiment.md) | Final compatibility report and request evidence for the experimental OpenMBEE View Editor deployments. |
 
 ## Methodology
 
@@ -72,6 +72,7 @@ flowchart LR
 | [Plans](plans/README.md) | Execution plan conventions for active and completed work. |
 | [MVP Feature Catalog](plans/active/mvp-feature-catalog.md) | Current MVP feature status, evidence, gaps, and validation work. |
 | [Usability Remediation](plans/active/usability-remediation.md) | Active work plan for converting the usability review into validated safety, onboarding, and bridge improvements. |
+| [View Editor Flexo Experiment](plans/completed/openmbee-view-editor-flexo-experiment.md) | Completed direct-compatibility spike and final adapter decision. |
 
 ## Reviews
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ flowchart LR
 | [Bridge Workflow](lab/flexo-syson-bridge.md) | Exporting from Flexo, rendering textual SysML v2, and importing into SysON. |
 | [Harness Engineering](lab/harness-engineering.md) | Understanding command surfaces, guardrails, evals, diagnostics, and agent-oriented operating rules. |
 | [Modeling Conventions](lab/modeling-conventions.md) | Checking which Flexo element types are rendered into textual SysML v2 and how names are sanitized. |
-| [View Editor Flexo Experiment](lab/view-editor-flexo-experiment.md) | Request evidence and interim compatibility findings for the experimental OpenMBEE View Editor deployment. |
+| [View Editor Flexo Experiment](lab/view-editor-flexo-experiment.md) | Request evidence and interim compatibility findings for the experimental OpenMBEE View Editor deployments. |
 
 ## Methodology
 

--- a/docs/lab/view-editor-flexo-experiment.md
+++ b/docs/lab/view-editor-flexo-experiment.md
@@ -1,7 +1,7 @@
 # OpenMBEE View Editor Flexo Experiment
 
 This page records redacted request evidence for the experimental OpenMBEE View
-Editor deployment in `deploy/view-editor/`.
+Editor deployments in `deploy/view-editor/` and `deploy/view-editor-5/`.
 
 The experiment is not part of the supported SysML v2 graphical workflow. SysON
 remains the documented graphical review path unless this experiment proves a
@@ -178,24 +178,75 @@ explanation for failure. However, the 5.x client still expects MMS-style
 authentication, org, ref, document/view, element, artifact, and search
 resources that are not exposed by Flexo SysML v2.
 
+## View Editor 5.x Durable Compose Probe
+
+Evidence captured on 2026-05-02 UTC.
+
+The disposable 5.0.0 source-build path was converted into
+`deploy/view-editor-5/` so the experiment can be repeated from repo-owned
+files. The compose file builds `Open-MBEE/exec-ve` tag `5.0.0`, runs the
+production webpack bundle directly, and serves it from nginx. The runtime
+config points View Editor at the same-origin URL:
+
+```text
+http://localhost:18092/api
+```
+
+nginx proxies that prefix to the Flexo SysML v2 container on the shared Docker
+network:
+
+```text
+http://flexo-sysmlv2:8080/
+```
+
+This avoids direct browser CORS failures and lets request traces show the
+underlying API contract mismatch.
+
+Observed HTTP request summary through the compose-managed container:
+
+| Request | Status | Response summary |
+| --- | ---: | --- |
+| `GET http://localhost:18092/` | 200 | View Editor 5.0.0 HTML shell |
+| `GET http://localhost:18092/config/config.json` | 200 | Runtime config with `apiUrl` set to `http://localhost:18092/api` |
+| `GET http://localhost:18092/api/projects` | 200 | Proxied Flexo SysML v2 project JSON array |
+| `GET http://localhost:18092/api/authentication` | 404 | Proxied Flexo SysML v2 has no View Editor 5.x authentication endpoint |
+| `GET http://localhost:18092/api/checkAuth` | 404 | Proxied Flexo SysML v2 has no View Editor 5.x auth-check endpoint |
+| `GET http://localhost:18092/api/orgs` | 404 | Proxied Flexo SysML v2 has no View Editor 5.x org endpoint |
+| `GET http://localhost:18092/api/projects/<project-id>/refs` | 404 | Proxied Flexo SysML v2 has no View Editor 5.x refs endpoint |
+
+Browser trace summary with Playwright:
+
+| Browser action | Observed result |
+| --- | --- |
+| Open `http://localhost:18092/` | Login page rendered with the configured experiment warning text. No API request was made before interaction. |
+| Submit login with synthetic credentials | Browser sent `POST http://localhost:18092/api/authentication`; response was 404 and the UI displayed `Not Found`. |
+| Load with a synthetic token already in local storage | Browser sent `GET http://localhost:18092/api/checkAuth`; response was 404 and the app remained on the login page. |
+
+Durable 5.x result: View Editor 5.0.0 can now be rebuilt and run from this repo
+without the older published image, and browser-level tracing confirms the first
+runtime blocker is API contract mismatch at authentication. The same-origin
+proxy removes CORS as the immediate explanation.
+
 ## Interim Compatibility Finding
 
-The published `openmbee/view-editor:3.6.1-omg` image is not directly compatible
-with the current local Flexo stack.
+The tested OpenMBEE View Editor paths are not directly compatible with the
+current local Flexo stack.
 
-There are two separate blockers:
+There are separate blockers:
 
 - Runtime/proxy blocker: in this image mode, legacy GET paths under
   `/alfresco/service/...` are handled by the View Editor single-page-app
   fallback instead of being proxied to the configured backend.
-- API contract blocker: neither Flexo Layer1 nor Flexo SysML v2 exposes the
-  legacy Alfresco MMS login, document, view, and project resources expected by
-  this View Editor generation. Flexo SysML v2 exposes OMG SysML v2 resources
-  instead.
+- Legacy API contract blocker: neither Flexo Layer1 nor Flexo SysML v2 exposes
+  the legacy Alfresco MMS login, document, view, and project resources expected
+  by the published `openmbee/view-editor:3.6.1-omg` image. Flexo SysML v2
+  exposes OMG SysML v2 resources instead.
+- View Editor 5.x API contract blocker: the source-built 5.0.0 client reaches
+  the configured same-origin proxy, but Flexo SysML v2 does not expose the MMS
+  5.x authentication, auth-check, org, ref, document/view, element, artifact,
+  and search resources it expects.
 
-The next useful probe is either to run a known legacy MMS/View Editor baseline
-to prove the image behavior against its intended backend, or to build the
-current View Editor 5.x source with explicit Flexo-facing configuration to see
-whether its newer container path proxies requests differently. Neither path is
-expected to remove the need for a legacy MMS document/view facade if View Editor
-is to work with Flexo SysML v2.
+The remaining useful work is to define the smallest adapter/facade boundary
+that could satisfy View Editor 5.x from Flexo SysML v2 data, or to run a known
+legacy MMS/View Editor baseline only if we need a control proving the View
+Editor client behavior against its intended backend.

--- a/docs/lab/view-editor-flexo-experiment.md
+++ b/docs/lab/view-editor-flexo-experiment.md
@@ -227,12 +227,34 @@ without the older published image, and browser-level tracing confirms the first
 runtime blocker is API contract mismatch at authentication. The same-origin
 proxy removes CORS as the immediate explanation.
 
-## Interim Compatibility Finding
+## Compatibility Report
+
+Final outcome: not compatible without an adapter.
 
 The tested OpenMBEE View Editor paths are not directly compatible with the
-current local Flexo stack.
+current local Flexo stack. This conclusion covers both the older published
+`openmbee/view-editor:3.6.1-omg` image and the source-built
+`Open-MBEE/exec-ve` 5.0.0 client.
 
-There are separate blockers:
+The decisive evidence is:
+
+- The published 3.6.1 image expects legacy Alfresco MMS paths under
+  `/alfresco/service/...`; those paths are absent from Flexo Layer1 and Flexo
+  SysML v2.
+- The source-built 5.0.0 client can load, render its login page, and reach the
+  same-origin `/api/` proxy to Flexo SysML v2, so CORS and static hosting are
+  not the immediate blocker.
+- View Editor 5.0.0 login sends `POST /api/authentication`; Flexo SysML v2
+  returns 404.
+- View Editor 5.0.0 auth validation sends `GET /api/checkAuth`; Flexo SysML v2
+  returns 404.
+- Flexo SysML v2 returns project discovery from `/projects`, but in OMG SysML
+  v2 shape rather than the MMS response shape expected by View Editor.
+- View Editor 5.0.0 repository and content endpoints such as `/orgs`,
+  `/projects/<project-id>/refs`, documents, views, elements, artifacts, and
+  search are not exposed by Flexo SysML v2.
+
+There are three separate findings:
 
 - Runtime/proxy blocker: in this image mode, legacy GET paths under
   `/alfresco/service/...` are handled by the View Editor single-page-app
@@ -246,7 +268,25 @@ There are separate blockers:
   5.x authentication, auth-check, org, ref, document/view, element, artifact,
   and search resources it expects.
 
-The remaining useful work is to define the smallest adapter/facade boundary
-that could satisfy View Editor 5.x from Flexo SysML v2 data, or to run a known
-legacy MMS/View Editor baseline only if we need a control proving the View
-Editor client behavior against its intended backend.
+## Minimal Adapter Boundary
+
+If View Editor 5.x remains a target, the next implementation path is a facade
+in front of Flexo SysML v2, not more container configuration. The smallest
+useful facade should start with read-only discovery and authentication
+compatibility:
+
+| Facade area | View Editor 5.x expectation | Flexo source |
+| --- | --- | --- |
+| Authentication | `POST /authentication`, `GET /checkAuth`, bearer token behavior, and user/session response shape | Flexo auth service and local token workflow |
+| Organizations | `GET /orgs` and optional org-filtered project listing | Synthetic default org or Flexo organization metadata if exposed elsewhere |
+| Projects | MMS-shaped `GET /projects` and `GET /projects/<project-id>` responses | Flexo SysML v2 `/projects` OMG project resources |
+| Refs | `GET /projects/<project-id>/refs` and branch/ref metadata | Flexo SysML v2 `defaultBranch` and branch resources |
+| Documents and views | `groups`, `documents`, `views`, and `views/<element-id>` endpoints | Derived read-only documents/views from SysML v2 packages/elements, or adapter-owned view records |
+| Elements | MMS-shaped element list and element detail endpoints | Flexo SysML v2 elements and relationships |
+| Search | `GET /projects/<project-id>/refs/<ref-id>/search` | Adapter-side index over Flexo SysML v2 elements |
+| Artifacts | Element artifact subresources | Out of scope for first read-only adapter unless required by a specific View Editor screen |
+
+The first adapter milestone should be read-only. It should allow login, project
+list, ref list, and opening a generated document/view for a synthetic Flexo
+project. Editing and artifact upload should remain out of scope until the read
+path proves that View Editor can display useful content from Flexo SysML v2.

--- a/docs/lab/view-editor-flexo-experiment.md
+++ b/docs/lab/view-editor-flexo-experiment.md
@@ -1,0 +1,130 @@
+# OpenMBEE View Editor Flexo Experiment
+
+This page records redacted request evidence for the experimental OpenMBEE View
+Editor deployment in `deploy/view-editor/`.
+
+The experiment is not part of the supported SysML v2 graphical workflow. SysON
+remains the documented graphical review path unless this experiment proves a
+viable View Editor integration.
+
+## Runtime Under Test
+
+Evidence captured on 2026-05-01.
+
+- View Editor image: `openmbee/view-editor:3.6.1-omg`
+- View Editor URL: `http://localhost:18091/`
+- Flexo Layer1 URL from host: `http://localhost:18080`
+- Flexo SysML v2 URL from host: `http://localhost:18083`
+- Flexo project used for path probes:
+  `aceb2496-9cca-4e97-9b17-bcfd5b076a4b`
+
+The published View Editor image uses the legacy Exec-era URL shape:
+
+- Login: `/alfresco/service/api/login`
+- Projects: `/alfresco/service/projects`
+- Orgs: `/alfresco/service/orgs`
+- Refs: `/alfresco/service/projects/<project-id>/refs`
+- Documents:
+  `/alfresco/service/projects/<project-id>/refs/<ref-id>/documents`
+
+The image rewrites `angular-mms-grunt-servers.json` at startup from
+`VE_HOST`, `VE_MMS_HOST`, and `VE_MMS_PORT`.
+
+## Layer1 Target
+
+View Editor was started with its default experiment target:
+
+```text
+VE_MMS_HOST=layer1-service
+VE_MMS_PORT=8080
+```
+
+The generated container proxy config was:
+
+```json
+{
+  "host": "localhost",
+  "acs_host": "layer1-service",
+  "acs_port": "8080"
+}
+```
+
+Observed request summary:
+
+| Request | Status | Response summary |
+| --- | ---: | --- |
+| `GET http://localhost:18091/` | 200 | View Editor HTML shell |
+| `GET http://localhost:18091/alfresco/service/projects` | 200 | View Editor HTML shell, not backend JSON |
+| `GET http://localhost:18091/alfresco/service/orgs` | 200 | View Editor HTML shell, not backend JSON |
+| `GET http://localhost:18091/alfresco/service/projects/<project-id>/refs` | 200 | View Editor HTML shell, not backend JSON |
+| `GET http://localhost:18091/alfresco/service/projects/<project-id>/refs/master/documents` | 200 | View Editor HTML shell, not backend JSON |
+| `POST http://localhost:18091/alfresco/service/api/login` | 404 | View Editor local server response: `Cannot POST /alfresco/service/api/login` |
+| `GET http://localhost:18080/alfresco/service/projects` | 404 | Direct Layer1 target has no legacy Alfresco service path |
+| `GET http://localhost:18080/projects` | 404 | Direct Layer1 target has no top-level projects resource |
+| `GET http://localhost:18080/orgs` | 401 | Direct Layer1 org endpoint requires authorization |
+| `POST http://localhost:18080/alfresco/service/api/login` | 404 | Direct Layer1 target has no legacy Alfresco login path |
+
+Layer1 result: the published View Editor image did not proxy the legacy GET
+paths to Layer1 in this Docker mode; it served the single-page app shell
+instead. The legacy login POST failed at the View Editor local server. Direct
+Layer1 probing also showed no legacy Alfresco login or project paths.
+
+## SysML v2 Target
+
+View Editor was restarted against the Flexo SysML v2 service:
+
+```text
+VE_MMS_HOST=flexo-sysmlv2
+VE_MMS_PORT=8080
+```
+
+The generated container proxy config was:
+
+```json
+{
+  "host": "localhost",
+  "acs_host": "flexo-sysmlv2",
+  "acs_port": "8080"
+}
+```
+
+Observed request summary:
+
+| Request | Status | Response summary |
+| --- | ---: | --- |
+| `GET http://localhost:18091/` | 200 | View Editor HTML shell |
+| `GET http://localhost:18091/alfresco/service/projects` | 200 | View Editor HTML shell, not backend JSON |
+| `GET http://localhost:18091/alfresco/service/orgs` | 200 | View Editor HTML shell, not backend JSON |
+| `GET http://localhost:18091/alfresco/service/projects/<project-id>/refs` | 200 | View Editor HTML shell, not backend JSON |
+| `GET http://localhost:18091/alfresco/service/projects/<project-id>/refs/master/documents` | 200 | View Editor HTML shell, not backend JSON |
+| `POST http://localhost:18091/alfresco/service/api/login` | 404 | View Editor local server response: `Cannot POST /alfresco/service/api/login` |
+| `GET http://localhost:18083/alfresco/service/projects` | 404 | Direct SysML v2 target has no legacy Alfresco service path |
+| `GET http://localhost:18083/projects` | 200 | Direct SysML v2 target returns OMG-style project JSON array |
+| `GET http://localhost:18083/orgs` | 404 | Direct SysML v2 target has no org endpoint |
+| `POST http://localhost:18083/alfresco/service/api/login` | 404 | Direct SysML v2 target has no legacy Alfresco login path |
+
+SysML v2 result: direct Flexo SysML v2 project discovery works at `/projects`,
+but the response shape is the OMG API shape, not the legacy MMS envelope that
+View Editor expects. The legacy View Editor paths are absent.
+
+## Interim Compatibility Finding
+
+The published `openmbee/view-editor:3.6.1-omg` image is not directly compatible
+with the current local Flexo stack.
+
+There are two separate blockers:
+
+- Runtime/proxy blocker: in this image mode, legacy GET paths under
+  `/alfresco/service/...` are handled by the View Editor single-page-app
+  fallback instead of being proxied to the configured backend.
+- API contract blocker: neither Flexo Layer1 nor Flexo SysML v2 exposes the
+  legacy Alfresco MMS login, document, view, and project resources expected by
+  this View Editor generation. Flexo SysML v2 exposes OMG SysML v2 resources
+  instead.
+
+The next useful probe is either to run a known legacy MMS/View Editor baseline
+to prove the image behavior against its intended backend, or to build the
+current View Editor 5.x source with explicit Flexo-facing configuration to see
+whether its newer container path proxies requests differently. Neither path is
+expected to remove the need for a legacy MMS document/view facade if View Editor
+is to work with Flexo SysML v2.

--- a/docs/lab/view-editor-flexo-experiment.md
+++ b/docs/lab/view-editor-flexo-experiment.md
@@ -107,6 +107,77 @@ SysML v2 result: direct Flexo SysML v2 project discovery works at `/projects`,
 but the response shape is the OMG API shape, not the legacy MMS envelope that
 View Editor expects. The legacy View Editor paths are absent.
 
+## View Editor 5.0.0 Source Build Probe
+
+Evidence captured on 2026-05-01.
+
+Public image lookup found no usable `openmbee/exec-ve:5.0.0` image. Docker Hub
+lists `openmbee/view-editor`, but the public OpenMBEE namespace only exposed
+the older `openmbee/view-editor:3.6.1-omg` View Editor image during this
+probe. The `Open-MBEE/exec-ve` source repository does contain a `5.0.0` tag
+with a root `Dockerfile`.
+
+The source-tag Dockerfile path was tested from `Open-MBEE/exec-ve` tag
+`5.0.0`:
+
+```bash
+docker build -t mbse-view-editor:5.0.0-local /tmp/exec-ve-5.0.0
+```
+
+That exact build did not complete. The tag's `.dockerignore` excludes dotfiles
+needed by the build's lint/format precheck, so ESLint first failed because it
+could not find its configuration. After copying the source tree to a temporary
+context and allowing the lint/format config files through `.dockerignore`, the
+build reached the lint step but failed on existing lint and formatting errors.
+
+As a narrower source-build proof, the same tag was built with a temporary
+Dockerfile that keeps the upstream dependency install and production webpack
+bundle, but bypasses the `prebuild` lint/format gate:
+
+```bash
+docker build \
+  -f /tmp/exec-ve-5.0.0-build/Dockerfile.webpack \
+  -t mbse-view-editor:5.0.0-webpack-local \
+  /tmp/exec-ve-5.0.0-build
+```
+
+That image built successfully and served the View Editor 5.0.0 static bundle
+from nginx. It also confirmed the 5.x runtime config file can be replaced after
+image build by mounting over:
+
+```text
+/usr/share/nginx/html/config/config.json
+```
+
+The local proof container was started on host port `18092` with `apiUrl`
+pointing at the Flexo SysML v2 service:
+
+```text
+View Editor 5.0.0 proof URL: http://localhost:18092/
+apiUrl: http://localhost:18083
+```
+
+Observed request summary:
+
+| Request | Status | Response summary |
+| --- | ---: | --- |
+| `GET http://localhost:18092/` | 200 | View Editor 5.0.0 HTML shell |
+| `GET http://localhost:18092/config/config.json` | 200 | Runtime config with `apiUrl` set to `http://localhost:18083` |
+| `GET http://localhost:18083/projects` | 200 | OMG-style project JSON array |
+| `GET http://localhost:18083/authentication` | 404 | Flexo SysML v2 has no View Editor 5.x authentication endpoint |
+| `GET http://localhost:18083/checkAuth` | 404 | Flexo SysML v2 has no View Editor 5.x auth-check endpoint |
+| `GET http://localhost:18083/orgs` | 404 | Flexo SysML v2 has no View Editor 5.x org endpoint |
+| `GET http://localhost:18083/projects/<project-id>/refs` | 404 | Flexo SysML v2 has no View Editor 5.x refs endpoint |
+| `OPTIONS http://localhost:18083/projects` from `http://localhost:18092` | 405 | Browser CORS preflight would not succeed for this direct static-app target |
+
+View Editor 5.0.0 result: the newer source line gives us a buildable local
+test path if we bypass the source tag's lint/format gate, and its runtime
+configuration can point directly at the Flexo SysML v2 host port. That removes
+the legacy `openmbee/view-editor:3.6.1-omg` proxy behavior as the only
+explanation for failure. However, the 5.x client still expects MMS-style
+authentication, org, ref, document/view, element, artifact, and search
+resources that are not exposed by Flexo SysML v2.
+
 ## Interim Compatibility Finding
 
 The published `openmbee/view-editor:3.6.1-omg` image is not directly compatible

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,4 +24,5 @@ use one.
 ## Active Plans
 
 - [MVP Feature Catalog](active/mvp-feature-catalog.md)
+- [OpenMBEE View Editor Flexo Experiment](active/openmbee-view-editor-flexo-experiment.md)
 - [Usability Remediation](active/usability-remediation.md)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,6 +24,7 @@ use one.
 ## Active Plans
 
 - [MVP Feature Catalog](active/mvp-feature-catalog.md)
+- [SysML JSON Rendering Reuse Spike](active/sysml-json-rendering-reuse-spike.md)
 - [Usability Remediation](active/usability-remediation.md)
 
 ## Completed Plans

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,5 +24,8 @@ use one.
 ## Active Plans
 
 - [MVP Feature Catalog](active/mvp-feature-catalog.md)
-- [OpenMBEE View Editor Flexo Experiment](active/openmbee-view-editor-flexo-experiment.md)
 - [Usability Remediation](active/usability-remediation.md)
+
+## Completed Plans
+
+- [OpenMBEE View Editor Flexo Experiment](completed/openmbee-view-editor-flexo-experiment.md)

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -43,7 +43,8 @@ Primary references:
 - `deploy/flexo-mms/README.md`
 - `scripts/flexo_mms_env.py`
 - `scripts/flexo_syson_bridge.py`
-- Future candidate: `deploy/view-editor/docker-compose.yml`
+- `deploy/view-editor/docker-compose.yml`
+- `deploy/view-editor/README.md`
 - Future candidate: `docs/lab/view-editor-flexo-experiment.md`
 
 ## View Editor Runtime Inventory
@@ -152,6 +153,12 @@ Out of scope for the first spike:
    - Avoid changing the supported Flexo compose file until compatibility is
      proven.
 
+   Status: complete as of 2026-05-01 for the legacy published image. The
+   compose file runs `openmbee/view-editor:3.6.1-omg` on host port `18091`,
+   joins the external `flexo-mms-test-network`, and defaults the View Editor
+   proxy target to `layer1-service:8080`. The target can be changed with
+   `VIEW_EDITOR_MMS_HOST` and `VIEW_EDITOR_MMS_PORT`.
+
 4. Probe backend targets in this order:
 
    - `http://layer1-service:8080` from inside Docker.
@@ -241,12 +248,19 @@ make live-eval
   document/view, element, artifact, and search endpoints. A quick local path
   check found `/authentication` is not present on the Flexo Layer1 or SysML v2
   ports.
+- 2026-05-01: Added the isolated `deploy/view-editor/` experiment for the
+  published `openmbee/view-editor:3.6.1-omg` image. Image inspection showed the
+  container serves on port `9000` and rewrites its proxy config from `VE_HOST`,
+  `VE_MMS_HOST`, and `VE_MMS_PORT`; the compose file exposes it on
+  `http://localhost:18091/` and joins the existing Flexo Docker network without
+  changing the supported Flexo deployment. A runtime smoke check started the
+  container and `curl http://localhost:18091/` returned HTTP 200 after the image
+  completed its Grunt asset build. Validation passed with `docker compose -f
+  deploy/view-editor/docker-compose.yml config --quiet`, `make docs-build`, and
+  `make check`.
 
 ## Follow-Up Debt
 
-- Decide whether the next runtime probe should build View Editor 5.x from
-  source or start with the older published `openmbee/view-editor:3.6.1-omg`
-  image as a legacy baseline.
 - Decide where to store redacted request-trace summaries.
 - If an adapter is needed, define the minimal legacy MMS document/view facade
   required by View Editor.

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -1,0 +1,176 @@
+# OpenMBEE View Editor Flexo Experiment
+
+## Objective
+
+Evaluate whether OpenMBEE View Editor can be used with the current local Flexo
+MMS deployment, including `flexo-mms-sysmlv2`, and determine whether any
+compatibility layer is needed before treating it as a supported graphical
+frontend option.
+
+The experiment should answer:
+
+- Can View Editor authenticate against the local Flexo MMS auth service?
+- Can View Editor discover or open content from the local Flexo Layer1 API?
+- Can View Editor interact with SysML v2 projects exposed through
+  `flexo-mms-sysmlv2`?
+- If it fails, is the blocker configuration, authentication, CORS, or an API
+  contract mismatch between legacy MMS document/view resources and the OMG
+  SysML v2 API?
+
+## Background
+
+The current lab stack exposes:
+
+- Flexo Layer1 API: `http://localhost:18080`
+- Flexo auth login: `http://localhost:8082/login`
+- Flexo SysML v2 API: `http://localhost:18083`
+
+OpenMBEE's Flexo page describes `flexo-mms-sysmlv2` as an implementation of the
+OMG SysML v2 API Services Specification built on Flexo MMS. The View Editor
+documentation describes a client built around MMS REST API concepts such as
+model elements, Documents, and Views. Those contracts may not match directly.
+
+Primary references:
+
+- <https://www.openmbee.org/flexo.html>
+- <https://docs.openmbee.org/projects/ve/en/latest/index.html>
+- <https://github.com/Open-MBEE/flexo-mms-sysmlv2>
+
+## Relevant Files
+
+- `deploy/flexo-mms/docker-compose.yml`
+- `deploy/flexo-mms/README.md`
+- `scripts/flexo_mms_env.py`
+- `scripts/flexo_syson_bridge.py`
+- Future candidate: `deploy/view-editor/docker-compose.yml`
+- Future candidate: `docs/lab/view-editor-flexo-experiment.md`
+
+## Experiment Scope
+
+This is a contained spike. Do not add View Editor to the main supported workflow
+until the request traces prove a viable integration path.
+
+In scope:
+
+- Inspect View Editor documentation, source, or container configuration.
+- Run View Editor beside the current Flexo stack on the existing Docker network.
+- Try both Layer1 and SysML v2 service URLs as backend targets.
+- Capture browser/API request traces for login, project listing, content open,
+  and document/view operations.
+- Document the compatibility result.
+
+Out of scope for the first spike:
+
+- Building a production-grade adapter.
+- Migrating private models into View Editor.
+- Treating View Editor as a replacement for SysON.
+- Committing runtime credentials, generated private exports, logs, or browser
+  trace bundles.
+
+## Planned Steps
+
+1. Confirm the baseline Flexo deployment is healthy:
+
+   ```bash
+   python3 scripts/flexo_mms_env.py up --wait --timeout 60
+   python3 scripts/flexo_mms_env.py status --with-sysmlv2 --strict
+   python3 scripts/flexo_mms_env.py token
+   python3 scripts/flexo_syson_bridge.py flexo-list-projects
+   ```
+
+2. Inventory View Editor runtime requirements:
+
+   - Identify the current image or source repo to use.
+   - Record required environment variables and backend URL configuration.
+   - Determine whether configuration is build-time or runtime.
+   - Identify expected authentication flow and API paths.
+
+3. Create an isolated experimental compose file if needed:
+
+   - Use a separate `deploy/view-editor/` directory.
+   - Join the existing `flexo-mms-test-network`.
+   - Avoid changing the supported Flexo compose file until compatibility is
+     proven.
+
+4. Probe backend targets in this order:
+
+   - `http://layer1-service:8080` from inside Docker.
+   - `http://flexo-sysmlv2:8080` from inside Docker.
+   - `http://localhost:18080` from the browser.
+   - `http://localhost:18083` from the browser.
+
+5. Capture evidence:
+
+   - Browser console errors.
+   - Network request method, path, status, and response summary.
+   - Container logs from View Editor and Flexo services.
+   - Whether any operation reaches a useful model view.
+
+6. If direct Flexo integration fails, run or inspect a known legacy MMS/View
+   Editor baseline to separate View Editor setup issues from API mismatch.
+
+7. Write a compatibility report with one of these outcomes:
+
+   - Directly compatible.
+   - Partially compatible with configuration constraints.
+   - Not compatible without an adapter.
+   - Inconclusive, with exact missing evidence.
+
+## Expected Outcomes
+
+Most likely outcome: View Editor will not work directly with
+`flexo-mms-sysmlv2` because it expects legacy MMS document/view resources while
+the SysML v2 service exposes the OMG SysML v2 API.
+
+Useful partial outcome: authentication or basic Flexo Layer1 discovery works,
+but document/view operations fail. That would define the adapter boundary.
+
+Strong success outcome: View Editor can authenticate, discover content, and
+open or edit useful model views using the current Flexo stack without custom
+adapter code. If this happens, add a supported deployment path and user docs in
+a follow-up chunk.
+
+## Decisions And Tradeoffs
+
+- Treat View Editor as experimental until proven against request traces.
+- Keep SysON as the documented graphical SysML v2 review path for now.
+- Prefer isolated compose and documentation over modifying the stable Flexo
+  deployment during the spike.
+- Preserve private model boundaries; use synthetic or disposable projects only.
+
+## Validation Commands
+
+For planning-only changes:
+
+```bash
+make check
+```
+
+If the future spike adds compose or docs navigation:
+
+```bash
+docker compose -f deploy/view-editor/docker-compose.yml config --quiet
+make docs-build
+make share-check
+```
+
+If live services are running during the future spike:
+
+```bash
+make deployment-verify
+make live-eval
+```
+
+## Progress Log
+
+- 2026-05-01: Created the experiment plan after reviewing OpenMBEE Flexo and
+  View Editor references. The working hypothesis is that direct compatibility
+  is unlikely without an adapter, but request tracing is needed before closing
+  the question.
+
+## Follow-Up Debt
+
+- Identify the exact current View Editor image or source revision to test.
+- Decide where to store redacted request-trace summaries.
+- If an adapter is needed, define the minimal legacy MMS document/view facade
+  required by View Editor.

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -78,6 +78,10 @@ Out of scope for the first spike:
    python3 scripts/flexo_syson_bridge.py flexo-list-projects
    ```
 
+   Status: complete as of 2026-05-01. Flexo services started cleanly, strict
+   status passed, token issuance succeeded, and the SysML v2 project list was
+   reachable.
+
 2. Inventory View Editor runtime requirements:
 
    - Identify the current image or source repo to use.
@@ -167,6 +171,13 @@ make live-eval
   View Editor references. The working hypothesis is that direct compatibility
   is unlikely without an adapter, but request tracing is needed before closing
   the question.
+- 2026-05-01: Executed the Flexo baseline health chunk. `python3
+  scripts/flexo_mms_env.py up --wait --timeout 60` started all expected Flexo
+  MMS services, `python3 scripts/flexo_mms_env.py status --with-sysmlv2
+  --strict` passed, `python3 scripts/flexo_mms_env.py token` returned a JWT,
+  and `python3 scripts/flexo_syson_bridge.py flexo-list-projects` returned the
+  local projects `MVP Smoke Model` and `Bridge Probe`. The token value was not
+  recorded.
 
 ## Follow-Up Debt
 

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -98,6 +98,18 @@ resources. `GET /authentication` returned 404 on both local Layer1 and SysML v2
 ports, which is consistent with View Editor requiring a legacy MMS auth
 endpoint or an adapter rather than only the Flexo SSO login endpoint.
 
+Follow-up source-build note: the `Open-MBEE/exec-ve` tag `5.0.0` includes a
+root Dockerfile, but no public `openmbee/exec-ve:5.0.0` image was found. The
+tagged Dockerfile failed locally because the Docker context excluded lint and
+format configuration files and then failed on existing lint/format errors once
+those files were allowed through. A narrower temporary image that ran the
+production webpack bundle directly did build and serve View Editor 5.0.0 on
+`http://localhost:18092/`, with a mounted runtime `config/config.json` pointing
+`apiUrl` at `http://localhost:18083`. Direct Flexo probes still showed the 5.x
+client endpoints are absent: `/authentication`, `/checkAuth`, `/orgs`, and
+`/projects/<project-id>/refs` returned 404, while `/projects` returned only the
+OMG-style SysML v2 project array.
+
 ## Experiment Scope
 
 This is a contained spike. Do not add View Editor to the main supported workflow
@@ -187,6 +199,14 @@ Out of scope for the first spike:
 
 6. If direct Flexo integration fails, run or inspect a known legacy MMS/View
    Editor baseline to separate View Editor setup issues from API mismatch.
+
+   Status: partial as of 2026-05-01. A View Editor 5.0.0 source-build path was
+   inspected and a local webpack-only proof image was built. This separated the
+   older `openmbee/view-editor:3.6.1-omg` proxy behavior from the API contract
+   mismatch: View Editor 5.x can be served and configured against
+   `http://localhost:18083`, but Flexo SysML v2 still does not expose the 5.x
+   MMS authentication, org, ref, document/view, element, artifact, and search
+   endpoints.
 
 7. Write a compatibility report with one of these outcomes:
 
@@ -282,8 +302,21 @@ make live-eval
   `docs/lab/view-editor-flexo-experiment.md`. Validation passed with `docker
   compose -f deploy/view-editor/docker-compose.yml config --quiet`, `make
   docs-build`, and `make check`.
+- 2026-05-01: Investigated the requested View Editor 5.0.0 image path before
+  declaring adapter-only compatibility. No public `openmbee/exec-ve:5.0.0`
+  image was found, but the `Open-MBEE/exec-ve` `5.0.0` tag contains a
+  Dockerfile. The exact tagged build failed locally at the lint/format gate; a
+  temporary webpack-only image built successfully as
+  `mbse-view-editor:5.0.0-webpack-local` and served on
+  `http://localhost:18092/` with `apiUrl=http://localhost:18083`. Direct probes
+  against Flexo SysML v2 still returned 404 for View Editor 5.x
+  `/authentication`, `/checkAuth`, `/orgs`, and
+  `/projects/<project-id>/refs`; `/projects` remained reachable only as
+  OMG-style SysML v2 JSON.
 
 ## Follow-Up Debt
 
+- Decide whether to add a durable `deploy/view-editor-5/` source-build path or
+  keep the 5.0.0 webpack-only Dockerfile as disposable spike evidence.
 - If an adapter is needed, define the minimal legacy MMS document/view facade
-  required by View Editor.
+  required by View Editor 5.x.

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -45,7 +45,7 @@ Primary references:
 - `scripts/flexo_syson_bridge.py`
 - `deploy/view-editor/docker-compose.yml`
 - `deploy/view-editor/README.md`
-- Future candidate: `docs/lab/view-editor-flexo-experiment.md`
+- `docs/lab/view-editor-flexo-experiment.md`
 
 ## View Editor Runtime Inventory
 
@@ -166,12 +166,24 @@ Out of scope for the first spike:
    - `http://localhost:18080` from the browser.
    - `http://localhost:18083` from the browser.
 
+   Status: complete as of 2026-05-01 for HTTP-level proxy and backend shape
+   probes. The published View Editor image served the HTML shell for legacy
+   `GET /alfresco/service/...` paths and rejected legacy login POSTs locally.
+   Direct Flexo probes confirmed that Layer1 and SysML v2 do not expose the
+   legacy Alfresco MMS paths; SysML v2 does expose `/projects` as OMG-style
+   project JSON.
+
 5. Capture evidence:
 
    - Browser console errors.
    - Network request method, path, status, and response summary.
    - Container logs from View Editor and Flexo services.
    - Whether any operation reaches a useful model view.
+
+   Status: partial as of 2026-05-01. HTTP and container-log summaries are
+   captured in `docs/lab/view-editor-flexo-experiment.md`. Browser console
+   evidence is still pending and may not add much until a proxying or baseline
+   View Editor setup is available.
 
 6. If direct Flexo integration fails, run or inspect a known legacy MMS/View
    Editor baseline to separate View Editor setup issues from API mismatch.
@@ -258,9 +270,20 @@ make live-eval
   completed its Grunt asset build. Validation passed with `docker compose -f
   deploy/view-editor/docker-compose.yml config --quiet`, `make docs-build`, and
   `make check`.
+- 2026-05-01: Captured request evidence for the published View Editor image
+  against both `layer1-service:8080` and `flexo-sysmlv2:8080`. The image
+  generated the expected proxy config for each target, but legacy
+  `GET /alfresco/service/...` calls returned the View Editor HTML shell and the
+  legacy login POST returned `Cannot POST /alfresco/service/api/login`,
+  indicating the requests did not reach the configured backend. Direct backend
+  probes confirmed the legacy Alfresco MMS paths are absent from both Flexo
+  targets; SysML v2 only returned project data from `/projects` in OMG API
+  shape. The redacted evidence summary is in
+  `docs/lab/view-editor-flexo-experiment.md`. Validation passed with `docker
+  compose -f deploy/view-editor/docker-compose.yml config --quiet`, `make
+  docs-build`, and `make check`.
 
 ## Follow-Up Debt
 
-- Decide where to store redacted request-trace summaries.
 - If an adapter is needed, define the minimal legacy MMS document/view facade
   required by View Editor.

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -45,6 +45,8 @@ Primary references:
 - `scripts/flexo_syson_bridge.py`
 - `deploy/view-editor/docker-compose.yml`
 - `deploy/view-editor/README.md`
+- `deploy/view-editor-5/docker-compose.yml`
+- `deploy/view-editor-5/README.md`
 - `docs/lab/view-editor-flexo-experiment.md`
 
 ## View Editor Runtime Inventory
@@ -110,6 +112,13 @@ client endpoints are absent: `/authentication`, `/checkAuth`, `/orgs`, and
 `/projects/<project-id>/refs` returned 404, while `/projects` returned only the
 OMG-style SysML v2 project array.
 
+Durable source-build note: `deploy/view-editor-5/` now provides a repeatable
+source-build experiment for View Editor 5.0.0. It builds the production webpack
+bundle directly and serves it through nginx with `apiUrl` set to
+`http://localhost:18092/api`. nginx proxies `/api/` to
+`http://flexo-sysmlv2:8080/` on the shared Docker network so browser traces are
+not blocked first by CORS.
+
 ## Experiment Scope
 
 This is a contained spike. Do not add View Editor to the main supported workflow
@@ -165,11 +174,12 @@ Out of scope for the first spike:
    - Avoid changing the supported Flexo compose file until compatibility is
      proven.
 
-   Status: complete as of 2026-05-01 for the legacy published image. The
-   compose file runs `openmbee/view-editor:3.6.1-omg` on host port `18091`,
-   joins the external `flexo-mms-test-network`, and defaults the View Editor
-   proxy target to `layer1-service:8080`. The target can be changed with
-   `VIEW_EDITOR_MMS_HOST` and `VIEW_EDITOR_MMS_PORT`.
+   Status: complete as of 2026-05-02. The legacy compose file runs
+   `openmbee/view-editor:3.6.1-omg` on host port `18091`, joins the external
+   `flexo-mms-test-network`, and defaults the View Editor proxy target to
+   `layer1-service:8080`. The source-built 5.x compose file builds
+   `Open-MBEE/exec-ve` tag `5.0.0`, serves it on host port `18092`, and proxies
+   same-origin `/api/` requests to `flexo-sysmlv2:8080`.
 
 4. Probe backend targets in this order:
 
@@ -192,21 +202,23 @@ Out of scope for the first spike:
    - Container logs from View Editor and Flexo services.
    - Whether any operation reaches a useful model view.
 
-   Status: partial as of 2026-05-01. HTTP and container-log summaries are
-   captured in `docs/lab/view-editor-flexo-experiment.md`. Browser console
-   evidence is still pending and may not add much until a proxying or baseline
-   View Editor setup is available.
+   Status: complete for the direct-compatibility spike as of 2026-05-02. HTTP,
+   container-log, and browser-level summaries are captured in
+   `docs/lab/view-editor-flexo-experiment.md`. A Playwright login trace against
+   the source-built 5.x deployment showed `POST /api/authentication` returning
+   404. A synthetic-token trace showed `GET /api/checkAuth` returning 404.
 
 6. If direct Flexo integration fails, run or inspect a known legacy MMS/View
    Editor baseline to separate View Editor setup issues from API mismatch.
 
-   Status: partial as of 2026-05-01. A View Editor 5.0.0 source-build path was
-   inspected and a local webpack-only proof image was built. This separated the
-   older `openmbee/view-editor:3.6.1-omg` proxy behavior from the API contract
-   mismatch: View Editor 5.x can be served and configured against
-   `http://localhost:18083`, but Flexo SysML v2 still does not expose the 5.x
-   MMS authentication, org, ref, document/view, element, artifact, and search
-   endpoints.
+   Status: complete enough for direct compatibility as of 2026-05-02. A durable
+   source-built View Editor 5.0.0 deployment was added under
+   `deploy/view-editor-5/`. This separated the older
+   `openmbee/view-editor:3.6.1-omg` proxy behavior from the API contract
+   mismatch: View Editor 5.x can be served, configured, and browser-tested
+   against a same-origin Flexo SysML v2 proxy, but Flexo SysML v2 still does not
+   expose the 5.x MMS authentication, auth-check, org, ref, document/view,
+   element, artifact, and search endpoints.
 
 7. Write a compatibility report with one of these outcomes:
 
@@ -249,6 +261,7 @@ If the future spike adds compose or docs navigation:
 
 ```bash
 docker compose -f deploy/view-editor/docker-compose.yml config --quiet
+docker compose -f deploy/view-editor-5/docker-compose.yml config --quiet
 make docs-build
 make share-check
 ```
@@ -313,10 +326,21 @@ make live-eval
   `/authentication`, `/checkAuth`, `/orgs`, and
   `/projects/<project-id>/refs`; `/projects` remained reachable only as
   OMG-style SysML v2 JSON.
+- 2026-05-02: Added the durable `deploy/view-editor-5/` source-build
+  experiment. The compose path builds `Open-MBEE/exec-ve` tag `5.0.0`, runs the
+  production webpack bundle directly, serves it from nginx on
+  `http://localhost:18092/`, and proxies `http://localhost:18092/api/` to
+  `flexo-sysmlv2:8080`. HTTP probes through the proxy returned 200 for
+  `/api/projects` and 404 for `/api/authentication`, `/api/checkAuth`,
+  `/api/orgs`, and `/api/projects/<project-id>/refs`. Playwright browser traces
+  confirmed the login page renders, submitting synthetic credentials posts to
+  `/api/authentication` and receives 404, and a synthetic preloaded token
+  triggers `/api/checkAuth` and receives 404.
 
 ## Follow-Up Debt
 
-- Decide whether to add a durable `deploy/view-editor-5/` source-build path or
-  keep the 5.0.0 webpack-only Dockerfile as disposable spike evidence.
-- If an adapter is needed, define the minimal legacy MMS document/view facade
-  required by View Editor 5.x.
+- Write the compatibility report and close the direct-compatibility spike as
+  not compatible without an adapter unless a new control run changes the
+  evidence.
+- Define the minimal legacy MMS document/view facade required by View Editor
+  5.x.

--- a/docs/plans/active/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/active/openmbee-view-editor-flexo-experiment.md
@@ -35,6 +35,7 @@ Primary references:
 - <https://www.openmbee.org/flexo.html>
 - <https://docs.openmbee.org/projects/ve/en/latest/index.html>
 - <https://github.com/Open-MBEE/flexo-mms-sysmlv2>
+- <https://github.com/Open-MBEE/exec-ve>
 
 ## Relevant Files
 
@@ -44,6 +45,57 @@ Primary references:
 - `scripts/flexo_syson_bridge.py`
 - Future candidate: `deploy/view-editor/docker-compose.yml`
 - Future candidate: `docs/lab/view-editor-flexo-experiment.md`
+
+## View Editor Runtime Inventory
+
+Inventory completed on 2026-05-01 against `Open-MBEE/exec-ve` `develop`
+commit `25c66a3b06db8ce6278872d67bca260aaae98b94` and the public Docker Hub
+repository metadata.
+
+- Current source repository: <https://github.com/Open-MBEE/exec-ve>.
+- Latest GitHub release visible from the repository page: `5.0.0`.
+- Public Docker Hub repository: `openmbee/view-editor`.
+- Only public Docker tag returned by the Docker Hub registry API:
+  `3.6.1-omg`, last updated 2020-08-04.
+- `openmbee/view-editor:5.0.0`, `openmbee/view-editor:5.0.0-alpha`,
+  `openmbee/view-editor:develop`, and `openmbee/view-editor:latest` did not
+  have Docker manifests when checked locally with `docker manifest inspect`.
+- The source Dockerfile builds View Editor from source with Node and serves the
+  static bundle from nginx.
+- The `config/example.json` file configures `apiUrl`, `printUrl`, `basePath`,
+  branding, and login warning text. The example points `apiUrl` at
+  `http://localhost:8080`.
+- View Editor configuration is effectively build-time for source builds via
+  `VE_ENV=<env_name> yarn build`; the README also describes mounting a config
+  file into the container under `/opt/mbee/ve/config/<env_file_name>.json` for
+  the nginx image.
+- Runtime container knobs documented by the source README are `VE_PORT`,
+  `VE_PROTOCOL`, and `VE_ENV`.
+
+Observed client API expectations from `src/ve-utils/mms-api-client`:
+
+- Authentication: `POST <apiUrl>/authentication`, token stored in browser
+  local storage, and `GET <apiUrl>/checkAuth` for login checks.
+- Repository discovery: `/orgs`, `/projects`, `/projects?orgId=<orgId>`,
+  `/projects/<projectId>`, `/projects/<projectId>/refs`, commits, and mounts.
+- Document/view operations:
+  `/projects/<projectId>/refs/<refId>/groups`,
+  `/projects/<projectId>/refs/<refId>/documents`,
+  `/projects/<projectId>/refs/<refId>/views`,
+  `/projects/<projectId>/refs/<refId>/views/<elementId>`, and
+  `/projects/<projectId>/refs/<refId>/search`.
+- Element/artifact operations:
+  `/projects/<projectId>/refs/<refId>/elements`,
+  `/projects/<projectId>/refs/<refId>/elements/<elementId>`, and artifact
+  subresources below an element.
+
+Initial API-shape note: `GET http://localhost:18083/projects` returns the local
+Flexo SysML v2 projects, but as an OMG-style JSON array with `@id`, `@type`,
+`defaultBranch`, `description`, and `name`. View Editor source expects MMS
+response envelopes such as `projects`, `orgs`, `elements`, and document/view
+resources. `GET /authentication` returned 404 on both local Layer1 and SysML v2
+ports, which is consistent with View Editor requiring a legacy MMS auth
+endpoint or an adapter rather than only the Flexo SSO login endpoint.
 
 ## Experiment Scope
 
@@ -88,6 +140,10 @@ Out of scope for the first spike:
    - Record required environment variables and backend URL configuration.
    - Determine whether configuration is build-time or runtime.
    - Identify expected authentication flow and API paths.
+
+   Status: complete as of 2026-05-01. Use the source repository for a current
+   5.x experiment unless intentionally testing the older published
+   `openmbee/view-editor:3.6.1-omg` image as a legacy baseline.
 
 3. Create an isolated experimental compose file if needed:
 
@@ -178,10 +234,19 @@ make live-eval
   and `python3 scripts/flexo_syson_bridge.py flexo-list-projects` returned the
   local projects `MVP Smoke Model` and `Bridge Probe`. The token value was not
   recorded.
+- 2026-05-01: Inventoried View Editor source and container options. The current
+  source line is `Open-MBEE/exec-ve` 5.x, while Docker Hub only exposes the
+  older `openmbee/view-editor:3.6.1-omg` tag. Source inspection shows View
+  Editor is hard-wired to legacy MMS authentication, org/project/ref,
+  document/view, element, artifact, and search endpoints. A quick local path
+  check found `/authentication` is not present on the Flexo Layer1 or SysML v2
+  ports.
 
 ## Follow-Up Debt
 
-- Identify the exact current View Editor image or source revision to test.
+- Decide whether the next runtime probe should build View Editor 5.x from
+  source or start with the older published `openmbee/view-editor:3.6.1-omg`
+  image as a legacy baseline.
 - Decide where to store redacted request-trace summaries.
 - If an adapter is needed, define the minimal legacy MMS document/view facade
   required by View Editor.

--- a/docs/plans/active/sysml-json-rendering-reuse-spike.md
+++ b/docs/plans/active/sysml-json-rendering-reuse-spike.md
@@ -1,0 +1,156 @@
+# SysML JSON Rendering Reuse Spike
+
+## Objective
+
+Determine whether an existing open-source renderer or exporter can convert
+Flexo SysML v2 REST JSON into valid textual SysML before expanding the local
+Python renderer in `scripts/flexo_syson_bridge.py`.
+
+The spike should answer:
+
+- Is there a maintained tool that accepts SysML v2 API-shaped JSON and emits
+  `.sysml` directly?
+- Can SysON's textual exporter be reused by feeding Flexo JSON through an
+  existing SysON import or data-version path?
+- Can the OMG SysML v2 Pilot Implementation materialize API JSON into an EMF
+  model that can be serialized through its Xtext stack?
+- If no direct renderer exists, what is the smallest adapter boundary that
+  avoids owning a broad hand-written textual renderer?
+
+## Background
+
+The current bridge path is:
+
+```text
+Flexo SysML v2 REST JSON -> conservative Python .sysml rendering -> SysON import
+```
+
+The Python renderer is intentionally narrow. It supports enough element shapes
+for the current lab fixtures, but broad SysML v2 textual coverage would be a
+large maintenance commitment. Before growing that renderer, inspect and test
+the strongest reuse candidates:
+
+- Eclipse SysON textual export, which serializes SysON EMF SysML elements to
+  textual SysML.
+- The OMG SysML v2 Pilot Implementation Xtext and API tooling.
+- SysML v2 API clients or CLIs that might already provide JSON-to-text export.
+
+## Relevant Files
+
+- `scripts/flexo_syson_bridge.py`
+- `docs/lab/flexo-syson-bridge.md`
+- `docs/lab/modeling-conventions.md`
+- `docs/plans/active/sysml-json-rendering-reuse-spike.md`
+- `exports/examples/flexo/`
+- `evals/fixtures/`
+
+External source references to inspect:
+
+- <https://github.com/eclipse-syson/syson>
+- <https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation>
+- <https://github.com/Systems-Modeling/SysML-v2-API-Python-Client>
+
+## Planned Steps
+
+1. Capture the current known reuse candidates and their adapter requirements.
+
+   Status: started on 2026-05-02. Initial source inspection found no direct
+   Flexo JSON to `.sysml` CLI, but identified SysON's textual exporter as the
+   strongest reuse candidate.
+
+2. Probe SysON's REST/data-version import surface with a small Flexo-style
+   SysML v2 API JSON payload.
+
+   Acceptance criteria:
+
+   - Create or choose a disposable SysON project.
+   - Submit a minimal package/root payload using any exposed SysON REST
+     data-version or import endpoint that accepts API-shaped JSON.
+   - Export the resulting SysON document as textual SysML using SysON's
+     existing exporter.
+   - Record whether the path works without custom Java code.
+
+3. If the REST path is not viable, assess a Java harness around SysON's
+   serializer.
+
+   Acceptance criteria:
+
+   - Identify the minimum SysON modules needed to instantiate a SysML model
+     element and call `SysMLElementSerializer`.
+   - Determine whether Flexo API JSON can be mapped mechanically into SysON's
+     EMF model without depending on private SysON internals.
+   - Record license and packaging implications.
+
+4. Inspect the SysML v2 Pilot Implementation for API JSON to EMF to text
+   support.
+
+   Acceptance criteria:
+
+   - Confirm whether a supported or testable API JSON load path exists.
+   - If it exists, run a minimal package/root payload through it.
+   - If it does not exist, document the missing boundary and avoid treating the
+     Pilot stack as a near-term renderer.
+
+5. Compare options and make a recommendation.
+
+   Possible outcomes:
+
+   - Use SysON as the renderer by routing Flexo JSON through a supported SysON
+     import/export path.
+   - Build a narrow adapter from Flexo API JSON into SysON's serializer model.
+   - Keep the current Python renderer but constrain its scope and use SysON or
+     Pilot tooling only as validation/reference.
+   - Adopt a discovered direct JSON-to-text renderer if one exists and has
+     acceptable licensing and operational fit.
+
+## Progress Log
+
+- 2026-05-02: Created this spike plan after broad source and web inspection.
+  Initial findings:
+  - SysON has an active textual export stack centered on
+    `SysMLElementSerializer` and `SysMLv2DocumentExporter`, but it serializes
+    SysON EMF model objects rather than raw Flexo JSON.
+  - The SysML v2 Pilot Implementation includes Xtext serializers and
+    `SysML2JSON`, but no obvious documented API JSON to textual SysML CLI was
+    found in the first pass.
+  - The public SysML v2 API Python client appears to be a generated REST client,
+    not a textual renderer.
+
+## Validation Commands
+
+Run deterministic checks after changing tracked repo files:
+
+```bash
+make check
+```
+
+Use live service checks only when probing a running SysON or Flexo stack:
+
+```bash
+python3 scripts/flexo_mms_env.py status --with-sysmlv2 --strict
+docker compose -f deploy/syson/docker-compose.yml ps
+python3 scripts/flexo_syson_bridge.py flexo-list-projects
+```
+
+If the spike produces a reusable bridge path, add focused deterministic tests
+before updating the supported workflow documentation.
+
+## Decisions And Tradeoffs
+
+- Prefer using SysON's exporter as a service or harness over copying serializer
+  code into this repository.
+- Do not expand the local Python renderer beyond narrow fixture needs until the
+  SysON and Pilot reuse paths are tested.
+- Treat licensing as part of the technical decision. SysON and the Pilot
+  Implementation have different licenses, so vendoring code is a materially
+  different choice from invoking an external tool or service.
+- Keep real model exports and run evidence out of this repo; use synthetic
+  payloads or private workspaces for live probes.
+
+## Follow-Up Debt
+
+- Update `docs/lab/modeling-conventions.md` if the recommended rendering path
+  changes.
+- Update `docs/lab/flexo-syson-bridge.md` if the bridge flow changes from local
+  Python rendering to SysON-mediated rendering.
+- Add fixture coverage for any adopted adapter path.

--- a/docs/plans/completed/openmbee-view-editor-flexo-experiment.md
+++ b/docs/plans/completed/openmbee-view-editor-flexo-experiment.md
@@ -7,6 +7,9 @@ MMS deployment, including `flexo-mms-sysmlv2`, and determine whether any
 compatibility layer is needed before treating it as a supported graphical
 frontend option.
 
+Status: complete as of 2026-05-02. Final outcome: not compatible without an
+adapter.
+
 The experiment should answer:
 
 - Can View Editor authenticate against the local Flexo MMS auth service?
@@ -119,6 +122,50 @@ bundle directly and serves it through nginx with `apiUrl` set to
 `http://flexo-sysmlv2:8080/` on the shared Docker network so browser traces are
 not blocked first by CORS.
 
+## Final Decision
+
+Direct compatibility is closed as not compatible without an adapter.
+
+Evidence supporting the decision:
+
+- The published `openmbee/view-editor:3.6.1-omg` image expects legacy Alfresco
+  MMS paths under `/alfresco/service/...`; those paths are absent from Flexo
+  Layer1 and Flexo SysML v2.
+- The source-built `Open-MBEE/exec-ve` 5.0.0 client can be built, hosted, and
+  browser-tested from `deploy/view-editor-5/`, so the remaining blocker is not
+  only the old public Docker image.
+- The 5.0.0 client reaches the same-origin `/api/` proxy to Flexo SysML v2, but
+  `POST /api/authentication` and `GET /api/checkAuth` return 404.
+- `GET /api/projects` returns Flexo SysML v2 project JSON, but in OMG API shape
+  rather than the MMS envelope expected by View Editor.
+- 5.x repository and content paths such as `/api/orgs`,
+  `/api/projects/<project-id>/refs`, documents, views, elements, artifacts, and
+  search are not exposed by Flexo SysML v2.
+
+Direct View Editor/Flexo integration should therefore stay outside the
+supported workflow. SysON remains the supported graphical review path.
+
+## Adapter Boundary
+
+If View Editor remains a desired frontend, the next path is a read-only MMS
+facade in front of Flexo SysML v2.
+
+Minimal first milestone:
+
+- Provide View Editor-compatible `POST /authentication` and `GET /checkAuth`
+  using Flexo auth/token behavior.
+- Return a synthetic or discovered org list from `GET /orgs`.
+- Map Flexo SysML v2 `/projects` into MMS-shaped `GET /projects` and
+  `GET /projects/<project-id>` responses.
+- Map Flexo project branches into `GET /projects/<project-id>/refs`.
+- Generate enough read-only group/document/view responses for View Editor to
+  open a synthetic project.
+- Map Flexo SysML v2 elements into MMS-shaped element list/detail responses.
+- Add a small adapter-side search response over mapped elements.
+
+Keep editing, artifact upload, and round-trip persistence out of the first
+adapter milestone.
+
 ## Experiment Scope
 
 This is a contained spike. Do not add View Editor to the main supported workflow
@@ -226,6 +273,10 @@ Out of scope for the first spike:
    - Partially compatible with configuration constraints.
    - Not compatible without an adapter.
    - Inconclusive, with exact missing evidence.
+
+   Status: complete as of 2026-05-02. Outcome: not compatible without an
+   adapter. The compatibility report and minimal adapter boundary are captured
+   in `docs/lab/view-editor-flexo-experiment.md`.
 
 ## Expected Outcomes
 
@@ -336,11 +387,15 @@ make live-eval
   confirmed the login page renders, submitting synthetic credentials posts to
   `/api/authentication` and receives 404, and a synthetic preloaded token
   triggers `/api/checkAuth` and receives 404.
+- 2026-05-02: Closed the direct-compatibility spike as not compatible without
+  an adapter. The final report identifies a read-only View Editor 5.x facade as
+  the next implementation path and keeps SysON as the supported graphical
+  review workflow.
 
 ## Follow-Up Debt
 
-- Write the compatibility report and close the direct-compatibility spike as
-  not compatible without an adapter unless a new control run changes the
-  evidence.
-- Define the minimal legacy MMS document/view facade required by View Editor
-  5.x.
+- Build a small read-only View Editor 5.x facade only if View Editor remains a
+  product target.
+- Keep the View Editor experiments isolated from the supported Flexo/SysON
+  workflow until the facade can authenticate, list projects, list refs, and
+  open a generated document/view from a synthetic Flexo project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Overview: plans/README.md
       - MVP Feature Catalog: plans/active/mvp-feature-catalog.md
       - Usability Remediation: plans/active/usability-remediation.md
+      - View Editor Flexo Experiment: plans/completed/openmbee-view-editor-flexo-experiment.md
   - Reviews:
       - Usability Review: reviews/usability-review.md
       - Recommended Features Review: reviews/recommended-features.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Bridge Workflow: lab/flexo-syson-bridge.md
       - Harness Engineering: lab/harness-engineering.md
       - Modeling Conventions: lab/modeling-conventions.md
+      - View Editor Flexo Experiment: lab/view-editor-flexo-experiment.md
   - Methodology:
       - Verification Model Setup: methodology/sysml-v2-verification-model-setup.md
       - Transformation Pipeline: methodology/sysml-v2-transformation-pipeline-design.md


### PR DESCRIPTION
## Summary

- add and complete the OpenMBEE View Editor/Flexo compatibility experiment plan
- add isolated legacy and source-built View Editor experiment deployments
- document why direct View Editor/Flexo compatibility is not viable without an adapter
- add an active spike plan for reusing existing SysML JSON to textual SysML rendering paths before expanding the local renderer

## Validation

- `make check`

## Notes

This branch was rebased onto `origin/develop` before submission.