### PR TITLE
Add service API readiness waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ For first use, run the guided bootstrap:
 mbse-lab bootstrap --model-workspace ~/work/my-private-models
 ```
 
+Bootstrap starts Flexo and SysON, then waits for the Flexo SysML v2 projects API
+and SysON web UI before continuing.
+
 Use `mbse-lab init` when you only want to generate local env files and optional
 workspace scaffolding without starting containers.
 
@@ -186,6 +189,9 @@ mbse-lab services up
 mbse-lab services logs
 mbse-lab services down
 ```
+
+`mbse-lab services up` waits for selected service APIs by default. Use
+`--no-wait` to return immediately after container startup.
 
 Create a tiny first model after the services are running:
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -146,6 +146,7 @@ The bootstrap command:
 - creates `deploy/syson/.env` from the publishable example when needed
 - optionally initializes a private model workspace
 - starts Flexo and SysON
+- waits for the Flexo `/projects` API and SysON web UI to answer
 - initializes the Flexo SysML v2 org
 - backs up Flexo graph state after org initialization
 - runs final status checks
@@ -172,6 +173,10 @@ Start both Flexo and SysON:
 ```bash
 mbse-lab services up
 ```
+
+By default, `services up` waits for the selected service APIs before printing
+the service URLs. Use `--no-wait` only when you want to start containers and
+return immediately.
 
 Stop both service families without deleting runtime data:
 

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -501,6 +501,103 @@ class CliTests(unittest.TestCase):
         self.assertIn("dry-run: python3 scripts/flexo_mms_env.py up --wait --timeout 45", result.output)
         self.assertIn("dry-run: docker compose -f deploy/syson/docker-compose.yml up -d", result.output)
 
+    def test_wait_for_readiness_succeeds_after_retry(self) -> None:
+        probe = cli.ReadinessProbe("Demo API", "http://example.invalid/ready", "mbse-lab services up")
+        with (
+            mock.patch.object(cli, "fetch_status", side_effect=[None, 200]),
+            mock.patch.object(cli.time, "sleep") as sleep,
+        ):
+            cli.wait_for_readiness([probe], timeout=5, interval=0)
+
+        sleep.assert_called_once_with(0)
+
+    def test_wait_for_readiness_failure_explains_next_command(self) -> None:
+        probe = cli.ReadinessProbe("Demo API", "http://example.invalid/ready", "mbse-lab services up")
+        with (
+            mock.patch.object(cli, "fetch_status", return_value=None),
+            self.assertRaises(cli.click.ClickException) as raised,
+        ):
+            cli.wait_for_readiness([probe], timeout=0, interval=0)
+
+        self.assertIn("Service readiness failed after 0s", str(raised.exception))
+        self.assertIn("Demo API", str(raised.exception))
+        self.assertIn("no HTTP response", str(raised.exception))
+        self.assertIn("mbse-lab services up", str(raised.exception))
+
+    def test_services_up_waits_for_selected_service_apis(self) -> None:
+        runner = CliRunner()
+        with (
+            mock.patch.object(cli, "run_command") as run_command,
+            mock.patch.object(cli, "wait_for_readiness") as wait_for_readiness,
+        ):
+            result = runner.invoke(cli.main, ["--repo-root", str(ROOT), "services", "up", "--no-flexo"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        run_command.assert_called_once_with(
+            ["docker", "compose", "-f", "deploy/syson/docker-compose.yml", "up", "-d"],
+            ROOT,
+            False,
+        )
+        wait_for_readiness.assert_called_once()
+        probes = wait_for_readiness.call_args.args[0]
+        self.assertEqual([probe.label for probe in probes], ["SysON Web UI"])
+
+    def test_bootstrap_waits_for_service_readiness_after_start(self) -> None:
+        runner = CliRunner()
+        with (
+            mock.patch.object(cli, "run_command") as run_command,
+            mock.patch.object(cli, "ensure_syson_env"),
+            mock.patch.object(cli, "wait_for_readiness") as wait_for_readiness,
+        ):
+            result = runner.invoke(
+                cli.main,
+                [
+                    "--repo-root",
+                    str(ROOT),
+                    "bootstrap",
+                    "--skip-flexo-org",
+                    "--skip-status",
+                    "--timeout",
+                    "45",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(run_command.call_count, 3)
+        self.assertIn("init", run_command.call_args_list[0].args[0])
+        self.assertIn("up", run_command.call_args_list[1].args[0])
+        self.assertIn("deploy/syson/docker-compose.yml", run_command.call_args_list[2].args[0])
+        wait_for_readiness.assert_called_once()
+        self.assertEqual(wait_for_readiness.call_args.args[1], 45)
+
+    def test_first_model_preflight_failure_stops_before_creating_projects(self) -> None:
+        runner = CliRunner()
+        with (
+            mock.patch.object(
+                cli,
+                "wait_for_readiness",
+                side_effect=cli.click.ClickException("Service readiness failed after 1s: Flexo unavailable"),
+            ),
+            mock.patch.object(cli, "create_flexo_project") as create_flexo_project,
+        ):
+            result = runner.invoke(
+                cli.main,
+                [
+                    "--repo-root",
+                    str(ROOT),
+                    "first-model",
+                    "Demo",
+                    "--output-dir",
+                    "/tmp/mbse-lab-demo",
+                    "--timeout",
+                    "1",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertIn("Service readiness failed", result.output)
+        create_flexo_project.assert_not_called()
+
     def test_services_down_dry_run_stops_syson_before_flexo(self) -> None:
         runner = CliRunner()
         result = runner.invoke(cli.main, ["--repo-root", str(ROOT), "services", "down", "--dry-run"])

--- a/src/mbse_lab/cli.py
+++ b/src/mbse_lab/cli.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -122,6 +123,65 @@ def print_service_urls() -> None:
     click.echo("  Flexo SysML v2 API: http://localhost:18083")
     click.echo("  SysON Web UI:       http://localhost:18090")
     click.echo("  SysON GraphQL API:  http://localhost:18090/api/graphql")
+
+
+@dataclass(frozen=True)
+class ReadinessProbe:
+    label: str
+    url: str
+    next_step: str
+
+
+def readiness_probes(
+    flexo: bool = True,
+    syson: bool = True,
+    flexo_url: str = DEFAULT_FLEXO_URL,
+    syson_url: str = DEFAULT_SYSON_URL,
+) -> list[ReadinessProbe]:
+    probes: list[ReadinessProbe] = []
+    if flexo:
+        probes.append(
+            ReadinessProbe(
+                label="Flexo SysML v2 API",
+                url=f"{trim_url(flexo_url)}/projects",
+                next_step="mbse-lab services up --flexo --timeout 60",
+            )
+        )
+    if syson:
+        probes.append(
+            ReadinessProbe(
+                label="SysON Web UI",
+                url=f"{trim_url(syson_url)}/",
+                next_step="mbse-lab services up --syson --timeout 60",
+            )
+        )
+    return probes
+
+
+def wait_for_readiness(probes: list[ReadinessProbe], timeout: int, interval: float = 2.0) -> None:
+    if not probes:
+        return
+    deadline = time.monotonic() + max(timeout, 0)
+    pending = {probe.label: probe for probe in probes}
+    last_status: dict[str, int | None] = {probe.label: None for probe in probes}
+
+    while pending:
+        for label, probe in list(pending.items()):
+            status = fetch_status(probe.url)
+            last_status[label] = status
+            if status is not None and status < 500:
+                del pending[label]
+        if not pending:
+            click.echo("Service readiness checks passed.")
+            return
+        if time.monotonic() >= deadline:
+            details = []
+            for label, probe in pending.items():
+                status = last_status[label]
+                status_detail = f"last status {status}" if status is not None else "no HTTP response"
+                details.append(f"{label} at {probe.url} ({status_detail}; next: `{probe.next_step}`)")
+            raise click.ClickException(f"Service readiness failed after {timeout}s: " + "; ".join(details))
+        time.sleep(min(interval, max(deadline - time.monotonic(), 0)))
 
 
 def unique_lines(lines: list[str]) -> list[str]:
@@ -307,6 +367,8 @@ def bootstrap(
             dry_run,
         )
         run_command(["docker", "compose", "-f", "deploy/syson/docker-compose.yml", "up", "-d"], repo_root, dry_run)
+        if not dry_run:
+            wait_for_readiness(readiness_probes(), timeout)
 
     if not skip_flexo_org:
         run_command(["python3", "scripts/flexo_syson_bridge.py", "init-flexo-org"], repo_root, dry_run)
@@ -374,6 +436,8 @@ def first_model(
         click.echo(f"dry-run: create SysON project `{resolved_syson_project_name}` at {syson_url}")
         click.echo(f"dry-run: import package `{package_identifier}` into the SysON root package")
         return
+
+    wait_for_readiness(readiness_probes(flexo_url=flexo_url, syson_url=syson_url), timeout)
 
     package_id = str(uuid.uuid4())
     flexo_project = create_flexo_project(flexo_url, name, timeout)
@@ -579,8 +643,8 @@ def services() -> None:
 @services.command("up")
 @click.option("--flexo/--no-flexo", default=True, help="Start Flexo services.")
 @click.option("--syson/--no-syson", default=True, help="Start SysON services.")
-@click.option("--wait/--no-wait", default=True, help="Wait for Flexo health during startup.")
-@click.option("--timeout", type=int, default=60, show_default=True, help="Flexo startup wait timeout in seconds.")
+@click.option("--wait/--no-wait", default=True, help="Wait for selected service APIs during startup.")
+@click.option("--timeout", type=int, default=60, show_default=True, help="Startup readiness timeout in seconds.")
 @click.option("--dry-run", is_flag=True, help="Print commands without changing containers.")
 @click.pass_context
 def services_up(ctx: click.Context, flexo: bool, syson: bool, wait: bool, timeout: int, dry_run: bool) -> None:
@@ -594,6 +658,8 @@ def services_up(ctx: click.Context, flexo: bool, syson: bool, wait: bool, timeou
         run_flexo_env(ctx, args, dry_run)
     if syson:
         run_syson_compose(ctx, ["up", "-d"], dry_run)
+    if wait and not dry_run:
+        wait_for_readiness(readiness_probes(flexo=flexo, syson=syson), timeout)
     if not dry_run:
         print_service_urls()
 


### PR DESCRIPTION
## Summary

- add HTTP readiness probes for the Flexo SysML v2 projects API and SysON web UI
- make `bootstrap` and `services up` wait for selected service APIs before reporting readiness
- add a `first-model` preflight so missing services fail before creating projects
- document the new readiness behavior in README and CLI docs

Fixes #24.

## Validation

- `python3 -m unittest evals.test_bridge_cli`
- `make check`
- pre-commit hooks during commit: ruff, ruff-format, py compile, docs contract check, secret pattern scan