### PR TITLE
Point bootstrap to first model workflow

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -150,7 +150,8 @@ The bootstrap command:
 - initializes the Flexo SysML v2 org
 - backs up Flexo graph state after org initialization
 - runs final status checks
-- prints local service URLs and next commands
+- prints local service URLs and next commands, including
+  `mbse-lab first-model "My First Model"`
 
 Preview the planned operations without changing files or starting containers:
 

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -330,6 +330,7 @@ class CliTests(unittest.TestCase):
             self.assertIn("dry-run: python3 scripts/flexo_mms_env.py init --with-sysmlv2", result.output)
             self.assertIn("dry-run: copy deploy/syson/.env.example to deploy/syson/.env", result.output)
             self.assertIn(f"dry-run: initialize model workspace {workspace}", result.output)
+            self.assertIn('mbse-lab first-model "My First Model"', result.output)
             self.assertFalse(workspace.exists())
 
     def test_init_dry_run_prepares_files_without_starting_services(self) -> None:

--- a/src/mbse_lab/cli.py
+++ b/src/mbse_lab/cli.py
@@ -388,6 +388,7 @@ def bootstrap(
     click.echo("Next:")
     click.echo("  mbse-lab doctor")
     click.echo("  mbse-lab workspace env <private-workspace>")
+    click.echo('  mbse-lab first-model "My First Model"')
 
 
 @main.command("first-model")


### PR DESCRIPTION
## Summary

- add `mbse-lab first-model "My First Model"` to the final bootstrap next-step guidance
- cover the expected bootstrap next-step text in CLI tests
- update CLI docs so bootstrap output is documented as pointing to first-model

Fixes #21.

## Validation

- `python3 -m unittest evals.test_bridge_cli.CliTests.test_bootstrap_dry_run_prints_planned_setup_without_touching_workspace`
- `make check`
- pre-commit hooks during commit: ruff, ruff-format, py compile, docs contract check, secret pattern scan