### PR TITLE
Add routine bridge auto-create workflow

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -3,6 +3,10 @@ name: Live smoke
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: live-smoke-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,68 @@
+name: Live smoke
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: live-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      MBSE_MODEL_WORKSPACE: ${{ github.workspace }}/.live-smoke-models
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install CLI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install hatch
+          python -m pip install -e .
+
+      - name: Initialize lab files
+        run: mbse-lab init --model-workspace "$MBSE_MODEL_WORKSPACE" --no-workspace-git
+
+      - name: Start services
+        run: mbse-lab services up --timeout 180
+
+      - name: Initialize Flexo SysML v2 org
+        run: mbse-lab flexo init-org --timeout 60
+
+      - name: Run first-use smoke
+        run: mbse-lab smoke first-use --json-output --timeout 180
+
+      - name: Verify deployment contract
+        run: mbse-lab deployment verify --timeout 60
+
+      - name: Run live evals
+        run: make live-eval
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          mbse-lab diagnostics --public-safe --output diagnostics/live-smoke --timeout 30 --log-tail 80 || true
+
+      - name: Upload diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: live-smoke-diagnostics
+          path: diagnostics/live-smoke
+          if-no-files-found: ignore
+
+      - name: Stop services
+        if: always()
+        run: mbse-lab services down || true

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ example model without the full smoke workflow.
 | Stop services | `mbse-lab services down` | Keeps persisted service data. |
 | Create demo model | `mbse-lab first-model "My First Model"` | Creates one Flexo project and imports it into SysON. |
 | Prove first-use path | `mbse-lab smoke first-use --json-output` | Starts services, creates/imports a disposable model, and writes a report. |
-| Bridge existing model | `mbse-lab bridge run <flexo-project-id>` | Requires a target SysON project and namespace today. |
+| Bridge existing model | `mbse-lab bridge run <flexo-project-id> --create-syson-project "Imported From Flexo"` | Creates a SysON review project and imports into its root package. |
 | Collect diagnostics | `mbse-lab diagnostics` | Use after service failures. |
 | Generate report | `mbse-lab report` | Writes Markdown, HTML, and JSON under `reports/latest/`. |
 | Clean generated local output | `mbse-lab cleanup --dry-run` | Remove reports, diagnostics, runs, and temp output after previewing. |
@@ -248,8 +248,8 @@ Routine bridge operations are also available through the CLI:
 mbse-lab flexo list
 mbse-lab syson list
 mbse-lab bridge run <flexo-project-id> \
-  --syson-project-id <syson-project-id> \
-  --namespace-id <syson-root-package-id>
+  --create-syson-project "Imported From Flexo" \
+  --json-output
 ```
 
 Before sharing or publishing the tooling repo, run:
@@ -432,7 +432,7 @@ reset the environment.
 | Create a SysON project | `mbse-lab syson create "Imported From Flexo"` |
 | Find a SysON import namespace | `mbse-lab syson roots <syson-project-id>` |
 | Import a `.sysml` file into SysON | `mbse-lab bridge import exports/sysml/<flexo-project-id>.sysml --project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
-| Run the full Flexo-to-SysON pipeline | `mbse-lab bridge run <flexo-project-id> --syson-project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
+| Run the full Flexo-to-SysON pipeline | `mbse-lab bridge run <flexo-project-id> --create-syson-project "Imported From Flexo"` |
 
 Default artifacts are written under `exports/flexo/` and `exports/sysml/`, or
 under `$MBSE_MODEL_WORKSPACE/exports/` when the private workspace variable is

--- a/docs/lab/flexo-syson-bridge.md
+++ b/docs/lab/flexo-syson-bridge.md
@@ -81,7 +81,7 @@ for synthetic, publishable seed data.
 | Create project | `mbse-lab syson create "Imported From Flexo"` |
 | Find import namespace | `mbse-lab syson roots <syson-project-id>` |
 | Import SysML text | `mbse-lab bridge import exports/sysml/<flexo-project-id>.sysml --project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
-| Run full pipeline | `mbse-lab bridge run <flexo-project-id> --syson-project-id <syson-project-id> --namespace-id <syson-root-package-id>` |
+| Run full pipeline | `mbse-lab bridge run <flexo-project-id> --create-syson-project "Imported From Flexo"` |
 
 The roots command resolves the latest SysON REST commit before fetching root
 namespace elements. Use `mbse-lab syson roots <syson-project-id> --json-output`
@@ -91,9 +91,14 @@ For the full pipeline, the expanded CLI form is:
 
 ```bash
 mbse-lab bridge run <flexo-project-id> \
-  --syson-project-id <syson-project-id> \
-  --namespace-id <syson-root-package-id>
+  --create-syson-project "Imported From Flexo" \
+  --json-output
 ```
+
+Use `--syson-project-id` and `--namespace-id` when importing into an existing
+SysON project. With `--create-syson-project`, the bridge creates the review
+project, discovers its root package, writes the Flexo export, SysML text,
+render report, and run log, then prints the created SysON IDs and URL.
 
 ## Artifacts
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -416,9 +416,12 @@ mbse-lab bridge import exports/sysml/<flexo-project-id>.sysml \
   --project-id <syson-project-id> \
   --namespace-id <syson-root-package-id>
 mbse-lab bridge run <flexo-project-id> \
-  --syson-project-id <syson-project-id> \
-  --namespace-id <syson-root-package-id>
+  --create-syson-project "Imported From Flexo" \
+  --json-output
 ```
+
+Use `--syson-project-id` and `--namespace-id` instead when importing into an
+existing SysON project.
 
 Inspect and verify the container deployment contract:
 

--- a/docs/user-guide/release-process.md
+++ b/docs/user-guide/release-process.md
@@ -39,6 +39,11 @@ mbse-lab share-check
 The live smoke pass creates disposable Flexo and SysON projects and writes
 generated artifacts under the private model workspace.
 
+Before publishing a release, also run the manual GitHub Actions workflow
+`Live smoke` from the Actions tab. It starts Flexo and SysON, runs the
+first-use smoke workflow and live evals, and uploads a public-safe diagnostics
+artifact if the workflow fails.
+
 ## Troubleshooting Live Smoke
 
 If `syson-app` exits with a Postgres message such as:

--- a/evals/test_bridge_cli.py
+++ b/evals/test_bridge_cli.py
@@ -580,6 +580,36 @@ class CliTests(unittest.TestCase):
         self.assertIn("--namespace-id namespace-1", result.output)
         self.assertIn("--output-dir exports", result.output)
 
+    def test_bridge_run_create_syson_project_dry_run_shows_plan(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.main,
+            [
+                "--repo-root",
+                str(ROOT),
+                "bridge",
+                "run",
+                "flexo-project-1",
+                "--create-syson-project",
+                "Imported From Flexo",
+                "--json-output",
+                "--dry-run",
+            ],
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("dry-run: export Flexo project `flexo-project-1`", result.output)
+        self.assertIn("dry-run: create SysON review project `Imported From Flexo`", result.output)
+        self.assertIn("--create-syson-project Imported From Flexo", result.output)
+        self.assertIn("--json-output", result.output)
+
+    def test_bridge_run_requires_existing_or_created_syson_target(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli.main, ["--repo-root", str(ROOT), "bridge", "run", "flexo-project-1", "--dry-run"])
+
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertIn("Provide --syson-project-id and --namespace-id, or use --create-syson-project.", result.output)
+
     def test_services_up_dry_run_builds_start_commands(self) -> None:
         runner = CliRunner()
         result = runner.invoke(cli.main, ["--repo-root", str(ROOT), "services", "up", "--timeout", "45", "--dry-run"])

--- a/evals/test_bridge_render.py
+++ b/evals/test_bridge_render.py
@@ -204,6 +204,62 @@ class BridgeRenderTests(unittest.TestCase):
             self.assertEqual(record["steps"][2]["details"]["coverage_summary"]["unsupported_elements"], 1)
             self.assertEqual(json.loads(render_report.read_text(encoding="utf-8"))["summary"]["rendered_elements"], 5)
 
+    def test_bridge_run_can_create_syson_project_and_emit_json_summary(self) -> None:
+        fixture = ROOT / "evals" / "fixtures" / "flexo-basic-package.json"
+        snapshot = json.loads(fixture.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "exports"
+            run_log = Path(temp_dir) / "run.json"
+            args = argparse.Namespace(
+                flexo_project_id="project-1",
+                commit_id=None,
+                syson_project_id=None,
+                namespace_id=None,
+                create_syson_project="Imported From Flexo",
+                editing_context_id=None,
+                output_dir=output_dir,
+                run_log=run_log,
+                run_log_dir=Path(temp_dir) / "runs",
+                flexo_url="http://flexo.local",
+                syson_url="http://syson.local",
+                timeout=10,
+                json_output=True,
+            )
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with (
+                mock.patch.object(flexo_syson_bridge, "export_flexo_project", return_value=snapshot),
+                mock.patch.object(
+                    flexo_syson_bridge,
+                    "create_syson_project",
+                    return_value={
+                        "id": "syson-project-1",
+                        "name": "Imported From Flexo",
+                        "currentEditingContext": {"id": "ctx-1"},
+                    },
+                ),
+                mock.patch.object(flexo_syson_bridge, "syson_latest_commit_id", return_value="syson-commit-1"),
+                mock.patch.object(flexo_syson_bridge, "syson_root_package_id", return_value="namespace-1"),
+                mock.patch.object(
+                    flexo_syson_bridge,
+                    "import_sysml_text",
+                    return_value={"editing_context_id": "ctx-1", "result": {"status": "ok"}},
+                ),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+            ):
+                flexo_syson_bridge.cmd_flexo_to_syson(args)
+
+            summary = json.loads(stdout.getvalue())
+            record = json.loads(run_log.read_text(encoding="utf-8"))
+
+        self.assertEqual(summary["syson_project_id"], "syson-project-1")
+        self.assertEqual(summary["namespace_id"], "namespace-1")
+        self.assertEqual(summary["artifacts"]["render_report"], record["artifacts"]["render_report"])
+        self.assertIn("Created SysON project: syson-project-1", stderr.getvalue())
+        self.assertIn("discover-syson-root", [step["name"] for step in record["steps"]])
+
     def test_coverage_matrix_matches_renderer_registry(self) -> None:
         doc = (ROOT / "docs" / "lab" / "modeling-conventions.md").read_text(encoding="utf-8")
         matrix_types = set()

--- a/evals/test_bridge_workflow.py
+++ b/evals/test_bridge_workflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / "WORKFLOW.md"
+LIVE_SMOKE_WORKFLOW = ROOT / ".github" / "workflows" / "live-smoke.yml"
 
 
 class WorkflowContractTests(unittest.TestCase):
@@ -55,6 +56,16 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("docs/plans/completed/", text)
         self.assertIn("GitHub CI workflow runs pre-commit", text)
         self.assertIn("documentation is organized for MkDocs", text)
+
+    def test_live_smoke_workflow_is_manual_and_uploads_failure_diagnostics(self) -> None:
+        text = LIVE_SMOKE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", text)
+        self.assertIn("mbse-lab services up", text)
+        self.assertIn("mbse-lab smoke first-use --json-output", text)
+        self.assertIn("make live-eval", text)
+        self.assertIn("mbse-lab diagnostics --public-safe", text)
+        self.assertIn("actions/upload-artifact", text)
 
 
 if __name__ == "__main__":

--- a/src/mbse_lab/bridge/workflow.py
+++ b/src/mbse_lab/bridge/workflow.py
@@ -1259,6 +1259,23 @@ def cmd_syson_list_projects(args: argparse.Namespace) -> None:
 
 
 def cmd_syson_create_project(args: argparse.Namespace) -> None:
+    project = create_syson_project(
+        args.syson_url,
+        args.name,
+        args.timeout,
+        template_id=args.template_id,
+        library_ids=args.library_ids,
+    )
+    print(json.dumps(project, indent=2))
+
+
+def create_syson_project(
+    syson_url: str,
+    name: str,
+    timeout: int,
+    template_id: str = "sysmlv2-template",
+    library_ids: list[str] | None = None,
+) -> dict[str, Any]:
     mutation = """
     mutation CreateProject($input: CreateProjectInput!) {
       createProject(input: $input) {
@@ -1273,16 +1290,19 @@ def cmd_syson_create_project(args: argparse.Namespace) -> None:
     variables = {
         "input": {
             "id": str(uuid.uuid4()),
-            "name": args.name,
-            "templateId": args.template_id,
-            "libraryIds": args.library_ids,
+            "name": name,
+            "templateId": template_id,
+            "libraryIds": library_ids or [],
         }
     }
-    response = graphql(args.syson_url, mutation, variables, timeout=args.timeout)
+    response = graphql(syson_url, mutation, variables, timeout=timeout)
     result = response["data"]["createProject"]
     if result["__typename"] == "ErrorPayload":
         fail(result["message"])
-    print(json.dumps(result["project"], indent=2))
+    project = result["project"]
+    if not isinstance(project, dict):
+        fail("SysON createProject response was not an object")
+    return project
 
 
 def syson_latest_commit_id(syson_url: str, project_id: str, timeout: int) -> str:
@@ -1302,19 +1322,33 @@ def syson_latest_commit_id(syson_url: str, project_id: str, timeout: int) -> str
 def cmd_syson_roots(args: argparse.Namespace) -> None:
     project_id = args.project_id
     commit_id = syson_latest_commit_id(args.syson_url, project_id, args.timeout)
-    roots = request_json(
-        "GET",
-        (
-            f"{trim_url(args.syson_url)}/api/rest/projects/{urllib.parse.quote(project_id, safe='')}"
-            f"/commits/{urllib.parse.quote(commit_id, safe='')}/roots"
-        ),
-        timeout=args.timeout,
-    )
+    roots = syson_roots(args.syson_url, project_id, commit_id, args.timeout)
     if args.json:
         print(json.dumps(roots, indent=2))
         return
     for root in roots:
         print(f"{root.get('@id')}  {root.get('@type')}  {root.get('declaredName') or root.get('name')}")
+
+
+def syson_roots(syson_url: str, project_id: str, commit_id: str, timeout: int) -> list[dict[str, Any]]:
+    roots = request_json(
+        "GET",
+        (
+            f"{trim_url(syson_url)}/api/rest/projects/{urllib.parse.quote(project_id, safe='')}"
+            f"/commits/{urllib.parse.quote(commit_id, safe='')}/roots"
+        ),
+        timeout=timeout,
+    )
+    if not isinstance(roots, list):
+        fail(f"SysON roots response was not a list for project {project_id}")
+    return [root for root in roots if isinstance(root, dict)]
+
+
+def syson_root_package_id(syson_url: str, project_id: str, commit_id: str, timeout: int) -> str:
+    for root in syson_roots(syson_url, project_id, commit_id, timeout):
+        if root.get("@type") == "Package" and root.get("@id"):
+            return str(root["@id"])
+    fail(f"no root Package found in SysON project {project_id}")
 
 
 def syson_editing_context_id(syson_url: str, project_id: str, timeout: int) -> str:
@@ -1390,12 +1424,23 @@ def cmd_syson_import_text(args: argparse.Namespace) -> None:
 
 
 def cmd_flexo_to_syson(args: argparse.Namespace) -> None:
+    create_syson_project_name = getattr(args, "create_syson_project", None)
+    syson_project_id = args.syson_project_id
+    namespace_id = args.namespace_id
+    editing_context_id = args.editing_context_id
+    if create_syson_project_name and (syson_project_id or namespace_id):
+        fail("--create-syson-project cannot be combined with --syson-project-id or --namespace-id")
+    if not create_syson_project_name and (not syson_project_id or not namespace_id):
+        fail("provide --syson-project-id and --namespace-id, or use --create-syson-project")
+
     run_id = str(uuid.uuid4())
     workflow = "flexo-to-syson"
     log_path = args.run_log or run_log_path(args.run_log_dir, workflow, run_id)
     output_dir = args.output_dir or default_output_dir()
     if args.output_dir is None and not os.environ.get(MODEL_WORKSPACE_ENV):
         warn_repo_local_exports(output_dir)
+    json_output = getattr(args, "json_output", False)
+    log_info = (lambda message: print(message, file=sys.stderr)) if json_output else info
     started_at = utc_now()
     started_perf = time.perf_counter()
     record: dict[str, Any] = {
@@ -1403,12 +1448,14 @@ def cmd_flexo_to_syson(args: argparse.Namespace) -> None:
         "workflow": workflow,
         "status": "running",
         "started_at": started_at,
+        "run_log_path": str(log_path),
         "inputs": {
             "flexo_project_id": args.flexo_project_id,
             "commit_id": args.commit_id,
-            "syson_project_id": args.syson_project_id,
-            "namespace_id": args.namespace_id,
-            "editing_context_id_provided": bool(args.editing_context_id),
+            "syson_project_id": syson_project_id,
+            "namespace_id": namespace_id,
+            "create_syson_project": create_syson_project_name,
+            "editing_context_id_provided": bool(editing_context_id),
             "output_dir": str(output_dir),
             "flexo_url": args.flexo_url,
             "syson_url": args.syson_url,
@@ -1417,8 +1464,8 @@ def cmd_flexo_to_syson(args: argparse.Namespace) -> None:
         "artifacts": {},
         "flexo": {},
         "syson": {
-            "project_id": args.syson_project_id,
-            "namespace_id": args.namespace_id,
+            "project_id": syson_project_id,
+            "namespace_id": namespace_id,
         },
         "steps": [],
     }
@@ -1484,18 +1531,66 @@ def cmd_flexo_to_syson(args: argparse.Namespace) -> None:
         )
         record["artifacts"]["sysml_text"] = str(sysml_path)
         record["artifacts"]["render_report"] = str(render_report_path)
-        info(f"Wrote Flexo export: {export_path}")
-        info(f"Wrote SysML textual export: {sysml_path}")
-        info(f"Wrote render coverage report: {render_report_path}")
+        log_info(f"Wrote Flexo export: {export_path}")
+        log_info(f"Wrote SysML textual export: {sysml_path}")
+        log_info(f"Wrote render coverage report: {render_report_path}")
+
+        if create_syson_project_name:
+            step_start = utc_now()
+            step_perf = time.perf_counter()
+            syson_project = create_syson_project(args.syson_url, create_syson_project_name, args.timeout)
+            syson_project_id = str(syson_project["id"])
+            editing_context = syson_project.get("currentEditingContext") or {}
+            editing_context_id = (
+                str(editing_context["id"]) if isinstance(editing_context, dict) and editing_context.get("id") else None
+            )
+            add_step(
+                record,
+                "create-syson-project",
+                "succeeded",
+                step_start,
+                time.perf_counter() - step_perf,
+                {
+                    "project_id": syson_project_id,
+                    "project_name": syson_project.get("name"),
+                    "editing_context_id": editing_context_id,
+                },
+            )
+            record["syson"].update(
+                {
+                    "project_id": syson_project_id,
+                    "project_name": syson_project.get("name"),
+                    "editing_context_id": editing_context_id,
+                }
+            )
+            log_info(f"Created SysON project: {syson_project_id}")
+
+            step_start = utc_now()
+            step_perf = time.perf_counter()
+            syson_commit_id = syson_latest_commit_id(args.syson_url, syson_project_id, args.timeout)
+            namespace_id = syson_root_package_id(args.syson_url, syson_project_id, syson_commit_id, args.timeout)
+            add_step(
+                record,
+                "discover-syson-root",
+                "succeeded",
+                step_start,
+                time.perf_counter() - step_perf,
+                {"commit_id": syson_commit_id, "namespace_id": namespace_id},
+            )
+            record["syson"]["commit_id"] = syson_commit_id
+            record["syson"]["namespace_id"] = namespace_id
+            log_info(f"Discovered SysON root namespace: {namespace_id}")
+        else:
+            record["syson"].update({"project_id": syson_project_id, "namespace_id": namespace_id})
 
         step_start = utc_now()
         step_perf = time.perf_counter()
         import_result = import_sysml_text(
             args.syson_url,
-            args.syson_project_id,
-            args.namespace_id,
+            str(syson_project_id),
+            str(namespace_id),
             sysml_text,
-            args.editing_context_id,
+            editing_context_id,
             args.timeout,
         )
         add_step(
@@ -1508,7 +1603,7 @@ def cmd_flexo_to_syson(args: argparse.Namespace) -> None:
         )
         record["syson"]["editing_context_id"] = import_result["editing_context_id"]
         record["syson"]["import_result"] = import_result["result"]
-        info(f"Imported {sysml_path} into SysON project {args.syson_project_id}.")
+        log_info(f"Imported {sysml_path} into SysON project {syson_project_id}.")
         record["status"] = "succeeded"
     except BaseException as exc:
         record["status"] = "failed"
@@ -1522,7 +1617,47 @@ def cmd_flexo_to_syson(args: argparse.Namespace) -> None:
         record["completed_at"] = utc_now()
         record["duration_seconds"] = round(time.perf_counter() - started_perf, 6)
         write_run_log(log_path, record)
-        info(f"Wrote run log: {log_path}")
+        log_info(f"Wrote run log: {log_path}")
+    if json_output:
+        print(json.dumps(flexo_to_syson_summary(record, args.syson_url), indent=2, sort_keys=True))
+    elif record["status"] == "succeeded":
+        summary = flexo_to_syson_summary(record, args.syson_url)
+        info("Bridge run completed.")
+        info(f"  Flexo project:      {summary.get('flexo_project_id')}")
+        info(f"  SysON project:      {summary.get('syson_project_id')}")
+        info(f"  SysON namespace:    {summary.get('namespace_id')}")
+        info(f"  Flexo export:       {summary['artifacts'].get('flexo_export')}")
+        info(f"  SysML text:         {summary['artifacts'].get('sysml_text')}")
+        info(f"  Render report:      {summary['artifacts'].get('render_report')}")
+        info(f"  Run log:            {summary.get('run_log')}")
+        info(f"  Open SysON:         {summary.get('syson_url')}")
+
+
+def flexo_to_syson_summary(record: dict[str, Any], syson_url: str) -> dict[str, Any]:
+    syson = record.get("syson", {}) if isinstance(record.get("syson"), dict) else {}
+    flexo = record.get("flexo", {}) if isinstance(record.get("flexo"), dict) else {}
+    artifacts = record.get("artifacts", {}) if isinstance(record.get("artifacts"), dict) else {}
+    return {
+        "status": record.get("status"),
+        "run_id": record.get("run_id"),
+        "run_log": record.get("run_log_path"),
+        "flexo_project_id": flexo.get("project_id"),
+        "flexo_commit_id": flexo.get("commit_id"),
+        "syson_project_id": syson.get("project_id"),
+        "syson_project_name": syson.get("project_name"),
+        "namespace_id": syson.get("namespace_id"),
+        "editing_context_id": syson.get("editing_context_id"),
+        "artifacts": artifacts,
+        "render_summary": next(
+            (
+                step.get("details", {}).get("coverage_summary")
+                for step in record.get("steps", [])
+                if isinstance(step, dict) and step.get("name") == "render-sysml"
+            ),
+            None,
+        ),
+        "syson_url": trim_url(syson_url),
+    }
 
 
 def add_common_url_args(parser: argparse.ArgumentParser) -> None:
@@ -1644,8 +1779,11 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline = subparsers.add_parser("flexo-to-syson", help="Export from Flexo, render .sysml, and import into SysON")
     pipeline.add_argument("flexo_project_id")
     pipeline.add_argument("--commit-id")
-    pipeline.add_argument("--syson-project-id", required=True)
-    pipeline.add_argument("--namespace-id", required=True)
+    pipeline.add_argument("--syson-project-id")
+    pipeline.add_argument("--namespace-id")
+    pipeline.add_argument(
+        "--create-syson-project", help="Create a SysON review project and import into its root package."
+    )
     pipeline.add_argument("--editing-context-id")
     pipeline.add_argument(
         "--output-dir",
@@ -1659,6 +1797,7 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline.add_argument("--run-log-dir", type=Path, default=DEFAULT_RUN_DIR, help="Directory for generated run logs.")
     pipeline.add_argument("--flexo-url", default=DEFAULT_FLEXO_URL)
     pipeline.add_argument("--syson-url", default=DEFAULT_SYSON_URL)
+    pipeline.add_argument("--json-output", action="store_true")
     add_common_url_args(pipeline)
     pipeline.set_defaults(func=cmd_flexo_to_syson)
 

--- a/src/mbse_lab/cli.py
+++ b/src/mbse_lab/cli.py
@@ -1336,8 +1336,9 @@ def bridge_import(
 @bridge.command("run")
 @click.argument("flexo_project_id")
 @click.option("--commit-id")
-@click.option("--syson-project-id", required=True)
-@click.option("--namespace-id", required=True)
+@click.option("--syson-project-id")
+@click.option("--namespace-id")
+@click.option("--create-syson-project", help="Create a SysON review project and import into its root package.")
 @click.option("--editing-context-id")
 @click.option("--output-dir", type=click.Path(path_type=Path))
 @click.option("--run-log", type=click.Path(path_type=Path))
@@ -1345,6 +1346,7 @@ def bridge_import(
 @click.option("--flexo-url", default=DEFAULT_FLEXO_URL, show_default=True)
 @click.option("--syson-url", default=DEFAULT_SYSON_URL, show_default=True)
 @click.option("--timeout", type=int, default=30, show_default=True)
+@click.option("--json-output", is_flag=True, help="Print a machine-readable JSON summary.")
 @click.option("--dry-run", is_flag=True)
 @click.option(
     "--allow-repo-exports",
@@ -1356,8 +1358,9 @@ def bridge_run(
     ctx: click.Context,
     flexo_project_id: str,
     commit_id: str | None,
-    syson_project_id: str,
-    namespace_id: str,
+    syson_project_id: str | None,
+    namespace_id: str | None,
+    create_syson_project: str | None,
     editing_context_id: str | None,
     output_dir: Path | None,
     run_log: Path | None,
@@ -1365,19 +1368,22 @@ def bridge_run(
     flexo_url: str,
     syson_url: str,
     timeout: int,
+    json_output: bool,
     dry_run: bool,
     allow_repo_exports: bool,
 ) -> None:
     """Export from Flexo, render SysML text, and import into SysON."""
+    if create_syson_project and (syson_project_id or namespace_id):
+        raise click.ClickException(
+            "--create-syson-project cannot be combined with --syson-project-id or --namespace-id"
+        )
+    if not create_syson_project and (not syson_project_id or not namespace_id):
+        raise click.ClickException("Provide --syson-project-id and --namespace-id, or use --create-syson-project.")
     if should_warn_repo_local_exports(output_dir, allow_repo_exports):
         warn_repo_local_exports(default_output_dir())
     args = [
         "flexo-to-syson",
         flexo_project_id,
-        "--syson-project-id",
-        syson_project_id,
-        "--namespace-id",
-        namespace_id,
         "--flexo-url",
         flexo_url,
         "--syson-url",
@@ -1385,6 +1391,12 @@ def bridge_run(
         "--timeout",
         str(timeout),
     ]
+    if create_syson_project:
+        args.extend(["--create-syson-project", create_syson_project])
+    else:
+        args.extend(["--syson-project-id", syson_project_id, "--namespace-id", namespace_id])
+    if json_output:
+        args.append("--json-output")
     for option, value in (
         ("--commit-id", commit_id),
         ("--editing-context-id", editing_context_id),
@@ -1394,6 +1406,16 @@ def bridge_run(
     ):
         if value:
             args.extend([option, str(value)])
+    if dry_run and create_syson_project:
+        for step in (
+            f"export Flexo project `{flexo_project_id}`",
+            "render SysML text and render coverage report",
+            f"create SysON review project `{create_syson_project}`",
+            "discover SysON root namespace",
+            "import rendered SysML into SysON",
+            "write bridge run log",
+        ):
+            click.echo(f"dry-run: {step}")
     run_bridge(ctx, args, dry_run)
 
 


### PR DESCRIPTION
## Summary
- add `mbse-lab bridge run --create-syson-project ... --json-output` so routine bridge runs can create a SysON review project, discover its root namespace, import the rendered SysML, and emit a concise run summary
- add the manual `Live smoke` GitHub Actions workflow with service startup, first-use smoke, deployment verification, live evals, and failure diagnostics artifact upload
- update bridge/release docs and add focused regression coverage for dry-run planning, JSON summary output, and the manual workflow contract

## Validation
- `python3 -m unittest evals.test_bridge_render evals.test_bridge_cli evals.test_bridge_workflow`
- `hatch run lint:all`
- `make check`
- `make docs-build`

Fixes #30.
Fixes #15.
Closes #39.