### PR TITLE
[codex] Add MBSE lab tool system model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ docs/lab/view-editor-flexo-experiment.md
                                   View Editor compatibility evidence
 docs/methodology/                 Reusable SysML v2 method guidance
 docs/model-specs/                 General-purpose model specifications
+docs/model-specs/mbse-lab-tool-system.md
+                                  SysML v2 model specification for this lab tool system
 docs/plans/README.md              Execution plan conventions
 deploy/flexo-mms/docker-compose.yml
 deploy/flexo-mms/README.md        Flexo deployment-specific operations

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ parts, attributes, ports, requirements, connections, interfaces, actions, and
 items. Unsupported element types remain preserved in the Flexo JSON export but
 are not emitted into the textual `.sysml` file yet. Diagram layout and live
 repository sync are not round-tripped.
+See `docs/user-guide/v0.1.0-limitations.md` for the release-scope limitation
+record and downstream development focus areas.
 
 See the [bridge workflow](docs/lab/flexo-syson-bridge.md) for the full command
 sequence, artifact table, render coverage report, and existing-project import

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ flowchart LR
 | [Safety And Sharing](user-guide/safety-and-sharing.md) | Credential, service-data, private-workspace, share-check, report, and cleanup boundaries. |
 | [Troubleshooting](user-guide/troubleshooting.md) | Symptom-oriented recovery paths for Docker, ports, Flexo org setup, SysON startup, and bridge imports. |
 | [Release Process](user-guide/release-process.md) | Preparing release branches, smoke testing, tagging, and syncing release work back to `develop`. |
+| [v0.1.0 Limitations](user-guide/v0.1.0-limitations.md) | Tracking release-scope limits, known gaps, and downstream development focus areas. |
 
 ## Local Lab
 
@@ -82,6 +83,7 @@ flowchart LR
 
 | Page | Use it for |
 | --- | --- |
+| [MBSE Lab Tool System](model-specs/mbse-lab-tool-system.md) | Modeling this repo's own requirements, architecture, workflows, verification concepts, and rendered fixture artifacts. |
 | [RF Link Budget](model-specs/rf-link-budget.md) | Modeling RF link margin, budget equations, requirements, analysis cases, and verification evidence. |
 | [CCA Rollup](model-specs/cca-rollup.md) | Modeling circuit-card power, mass, cost, labor, test, and rollup verification. |
 | [RF to Digital Signal Chain](model-specs/rf-to-digital-signal-chain.md) | Modeling RF front-end, ADC, DSP, signal quality, and response artifacts. |
@@ -97,6 +99,7 @@ flowchart LR
 | [MVP Feature Catalog](plans/active/mvp-feature-catalog.md) | Current MVP feature status, evidence, gaps, and validation work. |
 | [Usability Remediation](plans/active/usability-remediation.md) | Active work plan for converting the usability review into validated safety, onboarding, and bridge improvements. |
 | [View Editor Flexo Experiment](plans/completed/openmbee-view-editor-flexo-experiment.md) | Completed direct-compatibility spike and final adapter decision. |
+| [MBSE Lab SysML Model](plans/active/mbse-lab-sysml-model-plan.md) | Active plan for keeping the lab tool-system model, fixture, and curated render output aligned. |
 
 ## Reviews
 

--- a/docs/model-specs/mbse-lab-tool-system.md
+++ b/docs/model-specs/mbse-lab-tool-system.md
@@ -1,0 +1,285 @@
+# MBSE Lab Tool System SysML v2 Model Specification
+
+This document specifies the first SysML v2 model for this repository itself.
+The system of interest is the reusable MBSE lab tooling repo: the command-line
+tool, scripts, Docker deployments, bridge workflow, diagnostics, private
+workspace boundary, documentation, and verification harness.
+
+The model is intended to be useful as both:
+
+- A semantic model of the lab tool's landed requirements, architecture,
+  workflows, runtime services, generated artifacts, and verification evidence.
+- A publishable fixture source for improving the Flexo-to-SysON bridge and for
+  identifying the next high-value features.
+
+## Goals
+
+- Capture landed user-visible behavior as testable requirements.
+- Trace requirements to commands, scripts, docs, Docker services, generated
+  artifacts, and validation checks.
+- Represent the Flexo-to-SysON snapshot workflow as the core model interchange
+  path.
+- Preserve the repo boundary between shared tooling and private model data.
+- Use the model to expose gaps in automation, verification, rendering coverage,
+  and documentation.
+- Keep the initial fixture synthetic and small enough to publish in this repo.
+
+## Non-Goals
+
+- This model will not be the home for private user SysML v2 models.
+- This model will not claim full SysML v2 semantic coverage while the bridge
+  renderer intentionally supports a conservative subset.
+- This model will not model live bidirectional synchronization between Flexo and
+  SysON.
+- This model will not replace the Docker Compose files, CLI implementation,
+  tests, or documentation.
+
+## References
+
+- User guide: `README.md`
+- Workflow contract: `WORKFLOW.md`
+- Agent guide: `AGENTS.md`
+- CLI implementation: `src/mbse_lab/cli.py`
+- Flexo environment manager: `scripts/flexo_mms_env.py`
+- Flexo/SysON bridge: `scripts/flexo_syson_bridge.py`
+- Bridge notes: `docs/lab/flexo-syson-bridge.md`
+- Harness notes: `docs/lab/harness-engineering.md`
+- Modeling conventions: `docs/lab/modeling-conventions.md`
+- Private workspace guide: `docs/user-guide/private-model-workspaces.md`
+- Container deployment model: `docs/model-specs/container-deployment.md`
+- Active plan: `docs/plans/active/mbse-lab-sysml-model-plan.md`
+
+## Model Boundary
+
+The model covers the shared tooling system:
+
+```text
+repo and CLI
+  -> initialization and bootstrap
+  -> local Flexo and SysON runtime deployment
+  -> private model workspace boundary
+  -> Flexo project operations
+  -> SysON project operations
+  -> Flexo JSON export
+  -> conservative SysML text rendering
+  -> SysON textual import
+  -> diagnostics, reports, cleanup, and share checks
+  -> deterministic and optional live verification
+```
+
+Private model source, private Flexo JSON exports, private rendered snapshots,
+and run evidence from real programs are outside this model boundary unless
+curated as synthetic examples.
+
+## Stakeholders And Concerns
+
+| Stakeholder | Concern |
+| --- | --- |
+| First-time local user | Bootstrap should create the expected local files, start services when requested, and provide clear next commands. |
+| Returning local user | Service lifecycle, diagnostics, reports, cleanup, backup, and restore should be repeatable and non-destructive by default. |
+| Model author | Generated artifacts should default to a private workspace, not the shared tooling repo. |
+| Reviewer | Flexo snapshots should be importable into SysON for graphical review. |
+| Maintainer | Requirements, commands, docs, fixtures, and evals should stay traceable. |
+| Release publisher | The repo should pass share checks and avoid committed secrets or private model data. |
+| Future agent | Operating rules, plans, checks, and model structure should make work resumable. |
+
+## Viewpoints
+
+The first increment should support these views:
+
+- User workflow view: bootstrap, first model, bridge review, diagnostics, and
+  release validation.
+- Command surface view: CLI commands, Make targets, and lower-level scripts.
+- Runtime deployment view: Flexo stack, SysON stack, ports, data mounts, and API
+  probes.
+- Artifact view: env templates, runtime env files, Flexo exports, rendered
+  SysML, diagnostics bundles, run logs, reports, and fixtures.
+- Requirement trace view: landed requirements to implementation and checks.
+- Verification trace view: deterministic checks, live evals, docs checks,
+  share checks, and deployment verification.
+
+## MDA Methodology Alignment
+
+```text
+CIM-like layer
+  Stakeholders, setup needs, data safety concerns, graphical review needs,
+  release/share concerns, and agent handoff needs.
+
+PIM-like layer
+  Tool capabilities, bridge workflow, workspace boundary, artifact lifecycle,
+  diagnostics behavior, and verification intent independent of implementation.
+
+PSM-like layer
+  Click CLI commands, Python scripts, Docker Compose files, local host ports,
+  env files, ignored runtime paths, Make targets, and unittest evals.
+
+Generated and evidence artifacts
+  Flexo JSON exports, rendered .sysml snapshots, run logs, diagnostics bundles,
+  reports, deployment verification JSON, and validation command output.
+```
+
+## Recommended Package Structure
+
+```text
+MBSELabToolSystem
+  Libraries
+    Tooling
+    Workflow
+    Deployment
+    Verification
+  Stakeholders_Concerns
+  SystemContext
+  Requirements
+    BootstrapRequirements
+    ServiceLifecycleRequirements
+    PrivateWorkspaceRequirements
+    BridgeRequirements
+    RenderingRequirements
+    DiagnosticsReportingRequirements
+    ShareSafetyRequirements
+    VerificationRequirements
+    DocumentationRequirements
+  Architecture
+    CommandArchitecture
+    ScriptArchitecture
+    RuntimeDeploymentArchitecture
+    ArtifactArchitecture
+    BridgePipelineArchitecture
+  Workflows
+    BootstrapWorkflow
+    FirstModelWorkflow
+    FlexoToSysONSnapshotWorkflow
+    DiagnosticsWorkflow
+    ReleaseValidationWorkflow
+  Verification
+    DeterministicChecks
+    LiveServiceChecks
+    ShareSafetyChecks
+    DocumentationChecks
+    DeploymentVerificationChecks
+  Views_Viewpoints
+```
+
+## Landed Feature Requirements
+
+### Bootstrap And Initialization
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `BootstrapLocalLab` | The tool shall initialize local Flexo and SysON runtime files and optionally initialize a private model workspace. | `mbse-lab init`, `mbse-lab bootstrap`, `make init` |
+| `PreviewBootstrapChanges` | The tool shall provide dry-run modes for setup workflows that would otherwise change files or containers. | `mbse-lab init --dry-run`, `mbse-lab bootstrap --dry-run` |
+| `ReportServiceEndpoints` | The tool shall print local Flexo and SysON service URLs after startup-oriented workflows. | `mbse-lab services up`, `mbse-lab bootstrap` |
+
+### Service Lifecycle And Data Safety
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `ManageLocalServices` | The tool shall start, stop, restart, inspect, and read logs for the Flexo and SysON service families. | `mbse-lab services`, `make up`, `make down`, `make status`, `make logs` |
+| `AvoidDestructiveRuntimeReset` | Routine service stop commands shall not delete persisted runtime data. | `mbse-lab services down`, `WORKFLOW.md` |
+| `BackupFlexoGraphState` | The tool shall support backing up Flexo graph state and refreshing the startup dataset when graph state must persist. | `scripts/flexo_mms_env.py backup`, `make backup` |
+
+### Private Workspace Boundary
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `PreservePrivateModelBoundary` | The shared tooling repo shall not be the default long-term home for private model data. | `MBSE_MODEL_WORKSPACE`, private workspace docs |
+| `InitializePrivateWorkspace` | The CLI shall create and inspect a private model workspace layout. | `mbse-lab workspace init`, `mbse-lab workspace check` |
+| `DefaultGeneratedArtifactsToWorkspace` | Bridge artifacts shall default to the configured private workspace when `MBSE_MODEL_WORKSPACE` is set. | bridge commands, workspace docs |
+
+### Bridge And Rendering
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `ListAndCreateFlexoProjects` | The tool shall list, create, and export Flexo SysML v2 projects. | `mbse-lab flexo list`, `mbse-lab flexo create`, `mbse-lab flexo export` |
+| `ListAndCreateSysONProjects` | The tool shall list SysON projects, create SysON projects, and discover import roots. | `mbse-lab syson list`, `mbse-lab syson create`, `mbse-lab syson roots` |
+| `ProvideSnapshotBridge` | The tool shall move a Flexo snapshot into SysON through rendered SysML text. | `mbse-lab bridge run`, `flexo-to-syson` |
+| `RenderConservativeSysMLSubset` | The bridge shall render only verified SysML v2 element mappings and preserve unsupported source data in the raw export. | renderer evals, modeling conventions |
+| `RecordBridgeRunEvidence` | Full bridge runs shall write structured run logs by default. | `runs/flexo-to-syson/`, bridge run-log tests |
+
+### First Model Workflow
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `CreateFirstModelEndToEnd` | The CLI shall create a minimal Flexo model, export it, render it, create a SysON review project, and import the snapshot. | `mbse-lab first-model` |
+| `SummarizeFirstModelOutputs` | The first-model workflow shall print project IDs, artifact paths, and support machine-readable JSON output. | `mbse-lab first-model --json-output` |
+
+### Diagnostics, Reporting, Cleanup, And Share Safety
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `CollectRedactedDiagnostics` | The tool shall collect a redacted diagnostics bundle for service failures and handoff. | `mbse-lab diagnostics`, `make diagnostics` |
+| `GenerateStaticLabReport` | The tool shall generate Markdown, HTML, and JSON local lab reports. | `mbse-lab report` |
+| `CleanupGeneratedLocalArtifacts` | The tool shall remove generated reports, diagnostics, run logs, and temporary outputs on request. | `mbse-lab cleanup` |
+| `ProtectShareSafety` | The tool shall detect accidentally tracked runtime credentials, service data, private exports, run logs, reports, and secret-like patterns. | `mbse-lab share-check`, `make share-check` |
+
+### Verification And Documentation
+
+| Requirement | Statement | Evidence |
+| --- | --- | --- |
+| `SupportDeterministicValidation` | The repo shall provide deterministic validation that does not require live services. | `make check`, `make eval`, `make docs-check` |
+| `SupportOptionalLiveValidation` | The repo shall provide optional live service evals for Flexo, SysON, and deployment runtime behavior. | `make live-eval`, `mbse-lab deployment verify` |
+| `DocumentSupportedOperations` | User-facing docs shall describe setup, CLI use, private workspaces, bridge workflows, limitations, and release steps. | README and docs site |
+| `MaintainAgentHandoffContext` | Maintainer-facing docs shall preserve workflow expectations, task plans, validation commands, and data boundaries. | `AGENTS.md`, `WORKFLOW.md`, `docs/plans/` |
+
+## Initial Architecture Elements
+
+| Element | Kind | Responsibility |
+| --- | --- | --- |
+| `MBSELabToolingRepo` | part definition | Shared source, docs, fixtures, scripts, CLI, and deployment definitions. |
+| `CommandLineInterface` | part definition | User-facing command surface exposed as `mbse-lab`. |
+| `FlexoEnvironmentManager` | part usage | Flexo env generation, lifecycle, token, backup, and restore helper. |
+| `FlexoSysONBridge` | part usage | Flexo export, SysML rendering, SysON import, deployment contract, and run logs. |
+| `DiagnosticsCollector` | part usage | Redacted diagnostics bundle generation. |
+| `DockerDeployment` | part usage | Local Flexo and SysON Docker Compose runtime. |
+| `PrivateModelWorkspace` | part usage | External workspace for private models and generated artifacts. |
+| `VerificationHarness` | part usage | Deterministic evals, docs checks, share checks, and optional live evals. |
+
+## Initial Workflow Elements
+
+| Workflow | Purpose |
+| --- | --- |
+| `BootstrapWorkflow` | Prepare local files, optional private workspace, services, Flexo org, backup, and status checks. |
+| `FirstModelWorkflow` | Create a tiny model and prove the end-to-end Flexo-to-SysON path. |
+| `FlexoToSysONSnapshotWorkflow` | Export a selected Flexo commit, render SysML, and import into a SysON namespace. |
+| `DiagnosticsWorkflow` | Collect redacted local state, logs, probes, and deployment verification results. |
+| `ReleaseValidationWorkflow` | Run deterministic checks, docs checks, evals, share checks, and optional live validation. |
+
+## First Fixture Scope
+
+The first checked-in fixture should stay within the current renderer subset:
+
+- `Package`
+- `RequirementDefinition`
+- `PartDefinition`
+- `PartUsage`
+- `ActionDefinition`
+- `ItemDefinition`
+
+The fixture should cover the model backbone rather than every requirement. Rich
+traceability relationships can be added after the bridge supports more SysML v2
+relationship forms.
+
+The first curated rendered snapshot is:
+
+```text
+exports/examples/sysml/mbse-lab-tool-system.public.sysml
+```
+
+It is generated from:
+
+```text
+evals/fixtures/mbse-lab-tool-system.json
+```
+
+The deterministic render eval keeps the curated snapshot synchronized with the
+fixture.
+
+## Known Model Gaps
+
+- Requirement satisfaction, derivation, and verification relationships are not
+  rendered yet.
+- Command options and environment variables are documented but not modeled as
+  structured attributes in the first fixture.
+- Runtime deployment details are currently covered more deeply by the container
+  deployment fixture than by this tool-system fixture.
+- The model does not yet generate reports or docs from SysML source.

--- a/docs/plans/active/mbse-lab-sysml-model-plan.md
+++ b/docs/plans/active/mbse-lab-sysml-model-plan.md
@@ -1,0 +1,261 @@
+# MBSE Lab SysML v2 Model Plan
+
+## Objective
+
+Build a SysML v2 model of this repository as a tool system: the local MBSE lab
+kit that deploys Flexo MMS and SysON, manages private model workspaces, bridges
+Flexo snapshots into SysON, verifies runtime state, and protects shareability.
+
+The model should become both:
+
+- A semantic description of the tool's requirements, architecture, workflows,
+  runtime deployment, artifacts, and verification evidence.
+- A useful fixture source for improving the Flexo-to-SysON bridge, reporting,
+  deployment verification, and future model-template workflows.
+
+## Starting Position
+
+Starting with requirements for landed features makes sense, but the first step
+should be a short model-boundary and viewpoint pass. Without that boundary, the
+requirements risk becoming a flat command inventory instead of a traceable model
+of the tool system.
+
+Recommended starting sequence:
+
+1. Define model boundary, stakeholders, concerns, and viewpoints.
+2. Write requirements for landed behavior, grouped by user value.
+3. Map requirements to features, commands, scripts, docs, runtime services, and
+   verification checks.
+4. Add architecture and workflow structure once the requirement taxonomy is
+   stable.
+
+## Relevant Files
+
+- `README.md`
+- `WORKFLOW.md`
+- `AGENTS.md`
+- `Makefile`
+- `pyproject.toml`
+- `src/mbse_lab/cli.py`
+- `src/mbse_lab/model.py`
+- `src/mbse_lab/health.py`
+- `src/mbse_lab/reports.py`
+- `src/mbse_lab/share.py`
+- `src/mbse_lab/workspace.py`
+- `scripts/flexo_mms_env.py`
+- `scripts/flexo_syson_bridge.py`
+- `scripts/collect_diagnostics.py`
+- `scripts/check_docs.py`
+- `deploy/flexo-mms/docker-compose.yml`
+- `deploy/syson/docker-compose.yml`
+- `docs/lab/flexo-syson-bridge.md`
+- `docs/lab/harness-engineering.md`
+- `docs/lab/modeling-conventions.md`
+- `docs/model-specs/container-deployment.md`
+- `docs/model-specs/enterprise-architecture.md`
+- `docs/user-guide/cli.md`
+- `docs/user-guide/private-model-workspaces.md`
+- `evals/fixtures/*.json`
+- `evals/test_bridge_*.py`
+- `evals/test_live_*.py`
+
+## Planned Model Artifacts
+
+- `docs/model-specs/mbse-lab-tool-system.md`: human-readable model
+  specification.
+- `evals/fixtures/mbse-lab-tool-system.json`: synthetic Flexo-style fixture for
+  deterministic renderer and analysis tests.
+- `exports/examples/sysml/mbse-lab-tool-system.public.sysml`: curated
+  publishable rendered textual snapshot, if it stays small and synthetic.
+- Optional future private-workspace artifact: richer live Flexo export generated
+  from the local model once the workflow is stable.
+
+## Planned Package Structure
+
+```text
+MBSELabToolSystem
+  Libraries
+    Tooling
+    Workflow
+    Deployment
+    Verification
+  Metadata
+  Stakeholders_Concerns
+  SystemContext
+  Requirements
+    BootstrapRequirements
+    ServiceLifecycleRequirements
+    PrivateWorkspaceRequirements
+    BridgeRequirements
+    ModelRenderingRequirements
+    DiagnosticsReportingRequirements
+    ShareSafetyRequirements
+    VerificationRequirements
+    DocumentationRequirements
+    ReleaseReadinessRequirements
+  Architecture
+    CommandArchitecture
+    ScriptArchitecture
+    RuntimeDeploymentArchitecture
+    ArtifactArchitecture
+    BridgePipelineArchitecture
+  Workflows
+    BootstrapWorkflow
+    FirstModelWorkflow
+    FlexoToSysONSnapshotWorkflow
+    DiagnosticsWorkflow
+    ReleaseValidationWorkflow
+  Verification
+    DeterministicChecks
+    LiveServiceChecks
+    ShareSafetyChecks
+    DocumentationChecks
+    DeploymentVerificationChecks
+  Views_Viewpoints
+    UserWorkflowViews
+    CommandSurfaceViews
+    RequirementTraceViews
+    DeploymentRuntimeViews
+    VerificationTraceViews
+```
+
+## Requirement Taxonomy
+
+Initial requirements should describe landed user-visible behavior, not desired
+future behavior. Candidate groups:
+
+- Bootstrap and initialization: repo discovery, env generation, optional private
+  workspace setup, dry-run behavior, service URL reporting.
+- Service lifecycle: start, stop, restart, status, logs, Flexo backup, Flexo
+  restore, and non-destructive data handling.
+- Private workspace boundary: `MBSE_MODEL_WORKSPACE`, generated artifact
+  defaults, workspace layout, shareable tooling repo separation.
+- Bridge workflow: Flexo project list/create/export, SysML render, SysON
+  project list/create/root discovery/import, full snapshot bridge, run logs.
+- First model workflow: tiny end-to-end package creation, export, render, SysON
+  review project creation, import, JSON summary.
+- Conservative rendering: supported element types, deterministic naming,
+  preservation of unsupported data in raw exports.
+- Diagnostics and reporting: diagnostics bundle, deployment verification report,
+  static report, cleanup.
+- Share safety: forbidden tracked paths, generated export warnings, secret-like
+  pattern scan, credential template boundaries.
+- Verification and CI: `make check`, deterministic evals, docs checks, workflow
+  checks, optional live evals, deployment contract verification.
+- Documentation and release readiness: CLI docs, private workspace docs, release
+  process, known limitations.
+
+## Planned Steps
+
+### Step 1: Scope And Viewpoints
+
+- Define the system of interest as the MBSE lab tooling repo, not the models it
+  helps users build.
+- Identify primary stakeholders: first-time user, returning local-lab user,
+  model author, maintainer, release publisher, future agent.
+- Capture concerns: setup success, data safety, repeatability, bridge fidelity,
+  diagnostic clarity, shareability, verification coverage.
+- Decide which views are needed for the first model increment.
+
+### Step 2: Landed Feature Requirements
+
+- Translate landed CLI, script, docs, deployment, and eval behavior into
+  requirement definitions/usages.
+- Keep requirements testable and traceable to existing commands or docs.
+- Avoid requirements for deferred features unless marked as future or
+  out-of-scope.
+
+### Step 3: Feature And Artifact Architecture
+
+- Model command groups, scripts, runtime services, environment files, generated
+  artifacts, ignored runtime data, and publishable fixtures.
+- Link architecture parts to requirements.
+- Reuse concepts from the existing container deployment model for Docker
+  services and runtime checks.
+
+### Step 4: Workflow Model
+
+- Model the main action flows:
+  - `mbse-lab bootstrap`
+  - `mbse-lab first-model`
+  - `mbse-lab bridge run`
+  - `mbse-lab diagnostics`
+  - release/share validation
+- Connect inputs, outputs, generated artifacts, and verification evidence.
+
+### Step 5: Verification Trace
+
+- Map each requirement group to deterministic checks, live evals, share checks,
+  docs checks, deployment checks, or manual release validation.
+- Identify requirements that currently lack automated verification.
+
+### Step 6: Publishable Fixture And Rendered Snapshot
+
+- Create a synthetic Flexo-style JSON fixture for the model subset supported by
+  the bridge renderer.
+- Render the fixture to SysML text.
+- Add deterministic eval coverage for key declarations and traces.
+
+### Step 7: Future Feature Backlog From Model Gaps
+
+- Use missing requirements, unverified requirements, and unsupported model
+  elements to prioritize new tool features.
+- Candidate future features include bridge review automation, richer render
+  evidence reports, model templates, snapshot diffs, CLI backup/restore polish,
+  and remote endpoint profiles.
+
+## Progress Log
+
+- 2026-05-01: Created initial plan. Decision: start with scope/viewpoints, then
+  requirements for landed behavior.
+- 2026-05-01: Added first model increment: tool-system model spec, synthetic
+  Flexo-style fixture, MkDocs navigation entry, and deterministic render eval.
+- 2026-05-01: Added curated rendered SysML snapshot generated from the fixture
+  and eval coverage to keep it synchronized.
+
+## Validation Commands
+
+Run after changing docs or model specs:
+
+```bash
+make docs-check
+```
+
+Run after adding fixtures or renderer assertions:
+
+```bash
+make eval
+make check
+```
+
+Run when the live model workflow is exercised against local services:
+
+```bash
+make live-eval
+mbse-lab deployment verify
+```
+
+Run before sharing generated artifacts:
+
+```bash
+mbse-lab share-check
+```
+
+## Decisions And Tradeoffs
+
+- The first model increment covers landed behavior only. Deferred features can
+  appear as model gaps or future requirements, but should not be mixed into the
+  current baseline.
+- Requirements come after boundary and viewpoint definition so they remain
+  organized by stakeholder concern and verification value.
+- The publishable fixture should stay synthetic and small enough to live in the
+  tooling repo.
+- Richer model exports, run evidence, and experimental traces should live in a
+  private model workspace unless explicitly curated for publication.
+
+## Follow-Up Debt
+
+- Decide how much traceability the current conservative renderer can represent
+  before requiring renderer expansion.
+- Decide whether the model should become the source for future docs/report
+  generation, or remain a verification and planning artifact.

--- a/docs/user-guide/v0.1.0-limitations.md
+++ b/docs/user-guide/v0.1.0-limitations.md
@@ -1,0 +1,93 @@
+# v0.1.0 Limitations
+
+This page records the known limitations for the `v0.1.0` local lab release so
+downstream work can focus on the highest-value gaps without rediscovering them.
+
+## Scope Boundary
+
+- The documented happy path is local Docker on a developer workstation.
+- Remote Flexo and SysON endpoint profiles are not a release promise, even
+  though several commands accept explicit URL options.
+- This repo is tooling, not a private model repository. Real models, private
+  exports, rendered snapshots, run logs, and evidence bundles should live in a
+  private model workspace.
+
+## Bridge And Model Fidelity
+
+- The Flexo-to-SysON path is snapshot based:
+
+  ```text
+  Flexo SysML v2 REST JSON -> SysML v2 textual .sysml -> SysON GraphQL import
+  ```
+
+- Live bidirectional synchronization between Flexo and SysON is not implemented.
+- Diagram layout and SysON graphical views are not round-tripped.
+- The renderer emits only the conservative subset documented in
+  `docs/lab/modeling-conventions.md`.
+- Requirement satisfaction, derivation, verification relationships, allocation,
+  imports, metadata, multiplicities, value expressions, and many specialized
+  SysML v2 relationship forms are not rendered yet.
+- Unsupported elements remain preserved in the raw Flexo JSON export but are not
+  emitted into the `.sysml` snapshot.
+- Render coverage reports count rendered, skipped, and unsupported elements, but
+  they are not yet impact analyses or semantic diffs.
+
+## SysON Import Behavior
+
+- SysON import depends on SysON's textual SysML parser and project/template
+  behavior.
+- A successful textual import does not guarantee that useful diagrams or
+  graphical layouts appear automatically.
+- The bridge imports into an existing namespace; users still need the target
+  SysON project and namespace when using the lower-level bridge command.
+
+## Deployment And Runtime Operations
+
+- The Docker Compose stacks are intended for local lab use, not production
+  hosting.
+- Routine stop commands preserve runtime data, but full lifecycle management of
+  SysON database backup/restore is not yet automated.
+- Flexo graph backup support exists, but users must choose when graph state is
+  important enough to persist.
+- Runtime credential handling is local-file based. The repo does not integrate
+  a production secrets manager.
+- Port conflict handling relies on documented `.env` overrides and diagnostics,
+  not automatic port selection.
+
+## Verification
+
+- `make check` and deterministic evals do not require live services.
+- Live evals are optional and require the local Docker stacks to be running.
+- The default CI path does not start the full Flexo and SysON runtime on every
+  push.
+- Share-safety checks are guardrails, not a complete secret-detection solution.
+
+## Packaging And Release
+
+- Installation from GitHub and editable local installs are documented.
+- Publishing to PyPI is deferred beyond `v0.1.0`.
+- Shell completion snippets are generated, but installer-specific completion
+  setup is left to users.
+
+## Model And Template Coverage
+
+- The MBSE lab tool-system model is an initial backbone model. It captures
+  landed requirements, architecture, workflows, and verification concepts, but
+  rich trace relationships are limited by the current renderer.
+- Published model fixtures are synthetic and intentionally small.
+- Rich reusable model templates are deferred beyond the tiny `first-model`
+  workflow.
+
+## Downstream Development Focus
+
+Recommended post-`v0.1.0` focus areas:
+
+1. Add a one-command `bridge review` workflow that creates the SysON review
+   project and namespace automatically.
+2. Expand the render coverage report into a richer bridge evidence report.
+3. Add snapshot diffing between Flexo exports and rendered SysML snapshots.
+4. Expand renderer support for traceability relationships and requirement
+   verification structure.
+5. Add CLI backup/restore polish for both Flexo and SysON runtime state.
+6. Decide whether remote endpoint profiles are in scope.
+7. Promote model specs into reusable model templates.

--- a/evals/fixtures/mbse-lab-tool-system.json
+++ b/evals/fixtures/mbse-lab-tool-system.json
@@ -1,0 +1,353 @@
+{
+  "branches": [
+    {
+      "@id": "mbse-lab-branch-1",
+      "@type": "Branch",
+      "head": {
+        "@id": "mbse-lab-commit-1"
+      },
+      "name": "Initial"
+    }
+  ],
+  "commit": {
+    "@id": "mbse-lab-commit-1",
+    "@type": "Commit",
+    "description": "MBSE lab tool system fixture commit"
+  },
+  "elements": [
+    {
+      "@id": "mbse-lab-package-root",
+      "@type": "Package",
+      "declaredName": "MBSE Lab Tool System",
+      "ownedElement": [
+        {
+          "@id": "mbse-lab-package-stakeholders"
+        },
+        {
+          "@id": "mbse-lab-package-requirements"
+        },
+        {
+          "@id": "mbse-lab-package-architecture"
+        },
+        {
+          "@id": "mbse-lab-package-workflows"
+        },
+        {
+          "@id": "mbse-lab-package-verification"
+        }
+      ]
+    },
+    {
+      "@id": "mbse-lab-package-stakeholders",
+      "@type": "Package",
+      "declaredName": "Stakeholders and Concerns",
+      "ownedElement": [
+        {
+          "@id": "stakeholder-first-time-user"
+        },
+        {
+          "@id": "stakeholder-model-author"
+        },
+        {
+          "@id": "stakeholder-maintainer"
+        },
+        {
+          "@id": "stakeholder-release-publisher"
+        },
+        {
+          "@id": "stakeholder-future-agent"
+        }
+      ]
+    },
+    {
+      "@id": "stakeholder-first-time-user",
+      "@type": "ItemDefinition",
+      "declaredName": "FirstTimeLocalUser"
+    },
+    {
+      "@id": "stakeholder-model-author",
+      "@type": "ItemDefinition",
+      "declaredName": "ModelAuthor"
+    },
+    {
+      "@id": "stakeholder-maintainer",
+      "@type": "ItemDefinition",
+      "declaredName": "Maintainer"
+    },
+    {
+      "@id": "stakeholder-release-publisher",
+      "@type": "ItemDefinition",
+      "declaredName": "ReleasePublisher"
+    },
+    {
+      "@id": "stakeholder-future-agent",
+      "@type": "ItemDefinition",
+      "declaredName": "FutureAgent"
+    },
+    {
+      "@id": "mbse-lab-package-requirements",
+      "@type": "Package",
+      "declaredName": "Landed Feature Requirements",
+      "ownedElement": [
+        {
+          "@id": "requirement-bootstrap-local-lab"
+        },
+        {
+          "@id": "requirement-manage-local-services"
+        },
+        {
+          "@id": "requirement-preserve-private-model-boundary"
+        },
+        {
+          "@id": "requirement-provide-snapshot-bridge"
+        },
+        {
+          "@id": "requirement-render-conservative-subset"
+        },
+        {
+          "@id": "requirement-create-first-model"
+        },
+        {
+          "@id": "requirement-collect-diagnostics"
+        },
+        {
+          "@id": "requirement-protect-share-safety"
+        },
+        {
+          "@id": "requirement-support-validation"
+        },
+        {
+          "@id": "requirement-document-operations"
+        }
+      ]
+    },
+    {
+      "@id": "requirement-bootstrap-local-lab",
+      "@type": "RequirementDefinition",
+      "declaredName": "BootstrapLocalLab"
+    },
+    {
+      "@id": "requirement-manage-local-services",
+      "@type": "RequirementDefinition",
+      "declaredName": "ManageLocalServices"
+    },
+    {
+      "@id": "requirement-preserve-private-model-boundary",
+      "@type": "RequirementDefinition",
+      "declaredName": "PreservePrivateModelBoundary"
+    },
+    {
+      "@id": "requirement-provide-snapshot-bridge",
+      "@type": "RequirementDefinition",
+      "declaredName": "ProvideSnapshotBridge"
+    },
+    {
+      "@id": "requirement-render-conservative-subset",
+      "@type": "RequirementDefinition",
+      "declaredName": "RenderConservativeSysMLSubset"
+    },
+    {
+      "@id": "requirement-create-first-model",
+      "@type": "RequirementDefinition",
+      "declaredName": "CreateFirstModelEndToEnd"
+    },
+    {
+      "@id": "requirement-collect-diagnostics",
+      "@type": "RequirementDefinition",
+      "declaredName": "CollectRedactedDiagnostics"
+    },
+    {
+      "@id": "requirement-protect-share-safety",
+      "@type": "RequirementDefinition",
+      "declaredName": "ProtectShareSafety"
+    },
+    {
+      "@id": "requirement-support-validation",
+      "@type": "RequirementDefinition",
+      "declaredName": "SupportDeterministicValidation"
+    },
+    {
+      "@id": "requirement-document-operations",
+      "@type": "RequirementDefinition",
+      "declaredName": "DocumentSupportedOperations"
+    },
+    {
+      "@id": "mbse-lab-package-architecture",
+      "@type": "Package",
+      "declaredName": "Architecture",
+      "ownedElement": [
+        {
+          "@id": "mbse-lab-tooling-repo"
+        }
+      ]
+    },
+    {
+      "@id": "mbse-lab-tooling-repo",
+      "@type": "PartDefinition",
+      "declaredName": "MBSELabToolingRepo",
+      "ownedElement": [
+        {
+          "@id": "architecture-cli"
+        },
+        {
+          "@id": "architecture-flexo-env-manager"
+        },
+        {
+          "@id": "architecture-flexo-syson-bridge"
+        },
+        {
+          "@id": "architecture-diagnostics"
+        },
+        {
+          "@id": "architecture-docker-deployment"
+        },
+        {
+          "@id": "architecture-private-workspace"
+        },
+        {
+          "@id": "architecture-verification-harness"
+        }
+      ]
+    },
+    {
+      "@id": "architecture-cli",
+      "@type": "PartUsage",
+      "declaredName": "commandLineInterface"
+    },
+    {
+      "@id": "architecture-flexo-env-manager",
+      "@type": "PartUsage",
+      "declaredName": "flexoEnvironmentManager"
+    },
+    {
+      "@id": "architecture-flexo-syson-bridge",
+      "@type": "PartUsage",
+      "declaredName": "flexoSysONBridge"
+    },
+    {
+      "@id": "architecture-diagnostics",
+      "@type": "PartUsage",
+      "declaredName": "diagnosticsCollector"
+    },
+    {
+      "@id": "architecture-docker-deployment",
+      "@type": "PartUsage",
+      "declaredName": "dockerDeployment"
+    },
+    {
+      "@id": "architecture-private-workspace",
+      "@type": "PartUsage",
+      "declaredName": "privateModelWorkspace"
+    },
+    {
+      "@id": "architecture-verification-harness",
+      "@type": "PartUsage",
+      "declaredName": "verificationHarness"
+    },
+    {
+      "@id": "mbse-lab-package-workflows",
+      "@type": "Package",
+      "declaredName": "Workflows",
+      "ownedElement": [
+        {
+          "@id": "workflow-bootstrap"
+        },
+        {
+          "@id": "workflow-first-model"
+        },
+        {
+          "@id": "workflow-flexo-to-syson"
+        },
+        {
+          "@id": "workflow-diagnostics"
+        },
+        {
+          "@id": "workflow-release-validation"
+        }
+      ]
+    },
+    {
+      "@id": "workflow-bootstrap",
+      "@type": "ActionDefinition",
+      "declaredName": "BootstrapWorkflow"
+    },
+    {
+      "@id": "workflow-first-model",
+      "@type": "ActionDefinition",
+      "declaredName": "FirstModelWorkflow"
+    },
+    {
+      "@id": "workflow-flexo-to-syson",
+      "@type": "ActionDefinition",
+      "declaredName": "FlexoToSysONSnapshotWorkflow"
+    },
+    {
+      "@id": "workflow-diagnostics",
+      "@type": "ActionDefinition",
+      "declaredName": "DiagnosticsWorkflow"
+    },
+    {
+      "@id": "workflow-release-validation",
+      "@type": "ActionDefinition",
+      "declaredName": "ReleaseValidationWorkflow"
+    },
+    {
+      "@id": "mbse-lab-package-verification",
+      "@type": "Package",
+      "declaredName": "Verification",
+      "ownedElement": [
+        {
+          "@id": "verification-deterministic-checks"
+        },
+        {
+          "@id": "verification-live-evals"
+        },
+        {
+          "@id": "verification-share-check"
+        },
+        {
+          "@id": "verification-deployment-verify"
+        },
+        {
+          "@id": "verification-docs-check"
+        }
+      ]
+    },
+    {
+      "@id": "verification-deterministic-checks",
+      "@type": "ActionDefinition",
+      "declaredName": "DeterministicCheckSuite"
+    },
+    {
+      "@id": "verification-live-evals",
+      "@type": "ActionDefinition",
+      "declaredName": "LiveServiceEvalSuite"
+    },
+    {
+      "@id": "verification-share-check",
+      "@type": "ActionDefinition",
+      "declaredName": "ShareSafetyCheck"
+    },
+    {
+      "@id": "verification-deployment-verify",
+      "@type": "ActionDefinition",
+      "declaredName": "DeploymentVerificationCheck"
+    },
+    {
+      "@id": "verification-docs-check",
+      "@type": "ActionDefinition",
+      "declaredName": "DocumentationCheck"
+    }
+  ],
+  "project": {
+    "@id": "mbse-lab-project-1",
+    "@type": "Project",
+    "name": "MBSE Lab Tool System Fixture"
+  },
+  "roots": [
+    {
+      "@id": "mbse-lab-package-root"
+    }
+  ],
+  "source": "flexo-sysmlv2"
+}

--- a/evals/test_bridge_render.py
+++ b/evals/test_bridge_render.py
@@ -320,6 +320,27 @@ class BridgeRenderTests(unittest.TestCase):
             ),
         )
 
+    def test_mbse_lab_tool_system_curated_snapshot_matches_fixture_render(self) -> None:
+        fixture = ROOT / "evals" / "fixtures" / "mbse-lab-tool-system.json"
+        snapshot_path = ROOT / "exports" / "examples" / "sysml" / "mbse-lab-tool-system.public.sysml"
+        snapshot = json.loads(fixture.read_text(encoding="utf-8"))
+
+        rendered, report = bridge_render.render_snapshot_with_report(snapshot)
+
+        self.assertEqual(rendered, snapshot_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            report["summary"],
+            {
+                "total_elements": 39,
+                "rendered_elements": 39,
+                "skipped_elements": 0,
+                "unsupported_elements": 0,
+                "types": 6,
+                "unsupported_types": 0,
+            },
+        )
+        self.assertEqual(report["warnings"], [])
+
     def test_container_deployment_fixture_renders_spec_backbone(self) -> None:
         fixture = ROOT / "evals" / "fixtures" / "container-deployment-basic.json"
         snapshot = json.loads(fixture.read_text(encoding="utf-8"))

--- a/exports/README.md
+++ b/exports/README.md
@@ -33,3 +33,22 @@ mbse-lab share-check
 That check blocks tracked generated exports under `exports/flexo/` and
 `exports/sysml/`. Force-add only synthetic examples under `exports/examples/`
 and use `.public.json` or `.public.sysml` suffixes for those curated artifacts.
+
+## Curated Examples
+
+The checked-in examples are synthetic and publishable. They are kept small so
+they can serve as renderer fixtures and documentation examples.
+
+```text
+exports/examples/sysml/mbse-lab-tool-system.public.sysml
+                                  Rendered textual snapshot of this repo's own
+                                  MBSE lab tool-system fixture
+```
+
+Regenerate the MBSE lab tool-system snapshot with:
+
+```bash
+PYTHONPATH=src python3 -m mbse_lab.cli bridge render \
+  evals/fixtures/mbse-lab-tool-system.json \
+  --output exports/examples/sysml/mbse-lab-tool-system.public.sysml
+```

--- a/exports/examples/sysml/mbse-lab-tool-system.public.sysml
+++ b/exports/examples/sysml/mbse-lab-tool-system.public.sysml
@@ -1,0 +1,50 @@
+// Generated from a Flexo SysML v2 REST export.
+// Project: MBSE Lab Tool System Fixture
+// Commit: mbse-lab-commit-1
+
+package MBSE_Lab_Tool_System {
+  package Stakeholders_and_Concerns {
+    item def FirstTimeLocalUser;
+    item def ModelAuthor;
+    item def Maintainer;
+    item def ReleasePublisher;
+    item def FutureAgent;
+  }
+  package Landed_Feature_Requirements {
+    requirement def BootstrapLocalLab;
+    requirement def ManageLocalServices;
+    requirement def PreservePrivateModelBoundary;
+    requirement def ProvideSnapshotBridge;
+    requirement def RenderConservativeSysMLSubset;
+    requirement def CreateFirstModelEndToEnd;
+    requirement def CollectRedactedDiagnostics;
+    requirement def ProtectShareSafety;
+    requirement def SupportDeterministicValidation;
+    requirement def DocumentSupportedOperations;
+  }
+  package Architecture {
+    part def MBSELabToolingRepo {
+      part commandLineInterface;
+      part flexoEnvironmentManager;
+      part flexoSysONBridge;
+      part diagnosticsCollector;
+      part dockerDeployment;
+      part privateModelWorkspace;
+      part verificationHarness;
+    }
+  }
+  package Workflows {
+    action def BootstrapWorkflow;
+    action def FirstModelWorkflow;
+    action def FlexoToSysONSnapshotWorkflow;
+    action def DiagnosticsWorkflow;
+    action def ReleaseValidationWorkflow;
+  }
+  package Verification {
+    action def DeterministicCheckSuite;
+    action def LiveServiceEvalSuite;
+    action def ShareSafetyCheck;
+    action def DeploymentVerificationCheck;
+    action def DocumentationCheck;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Safety And Sharing: user-guide/safety-and-sharing.md
       - Troubleshooting: user-guide/troubleshooting.md
       - Release Process: user-guide/release-process.md
+      - v0.1.0 Limitations: user-guide/v0.1.0-limitations.md
   - Local Lab:
       - Bridge Workflow: lab/flexo-syson-bridge.md
       - Harness Engineering: lab/harness-engineering.md
@@ -39,6 +40,7 @@ nav:
       - Verification Model Setup: methodology/sysml-v2-verification-model-setup.md
       - Transformation Pipeline: methodology/sysml-v2-transformation-pipeline-design.md
   - Model Specs:
+      - MBSE Lab Tool System: model-specs/mbse-lab-tool-system.md
       - RF Link Budget: model-specs/rf-link-budget.md
       - CCA Rollup: model-specs/cca-rollup.md
       - RF to Digital Signal Chain: model-specs/rf-to-digital-signal-chain.md
@@ -50,6 +52,7 @@ nav:
       - MVP Feature Catalog: plans/active/mvp-feature-catalog.md
       - Usability Remediation: plans/active/usability-remediation.md
       - View Editor Flexo Experiment: plans/completed/openmbee-view-editor-flexo-experiment.md
+      - MBSE Lab SysML Model: plans/active/mbse-lab-sysml-model-plan.md
   - Reviews:
       - Usability Review: reviews/usability-review.md
       - Recommended Features Review: reviews/recommended-features.md


### PR DESCRIPTION
## Summary

Adds the repo-owned MBSE lab tool-system model as a publishable SysML v2 fixture and documentation artifact.

## Changes

- Adds the MBSE lab tool-system model specification and active integration plan.
- Adds a synthetic Flexo-style fixture plus curated public SysML render output.
- Adds a deterministic renderer eval that keeps the curated snapshot aligned with the fixture and coverage report.
- Adds the v0.1.0 limitations page and navigation references, while using the existing render coverage report path instead of the older manifest implementation.

## Validation

- `python3 -m unittest evals.test_bridge_render`
- `make check`

## Notes

This intentionally carries forward the model/docs/example work only. It does not restore the previous custom render-manifest implementation because current `develop` already has render coverage reporting.